### PR TITLE
Fix memory leak / fix warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(mariadbclientpp ${mariadbclientpp_SOURCES} ${mariadbclientpp_PUBLIC_
 # target options
 target_link_libraries(mariadbclientpp ${MariaDBClient_LIBRARIES} pthread)
 target_include_directories(mariadbclientpp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include ${MariaDBClient_INCLUDE_DIRS})
+target_compile_options(mariadbclientpp PRIVATE -Wall -Wextra)
 
 # install configuration
 install(FILES ${mariadbclientpp_PUBLIC_HEADERS} DESTINATION include/mariadb++)

--- a/include/mariadb++/account.hpp
+++ b/include/mariadb++/account.hpp
@@ -21,6 +21,7 @@ typedef std::shared_ptr<account> account_ref;
 
 class option_arg {
    public:
+    virtual ~option_arg() = default;
     virtual const void *value() = 0;
 };
 

--- a/include/mariadb++/date_time.hpp
+++ b/include/mariadb++/date_time.hpp
@@ -179,7 +179,7 @@ class date_time : public time {
      * @param dt String containing ISO date
      * @return True on success
      */
-    bool set(const std::string& dt);
+    bool set(const std::string& dt) override;
 
     /**
      * Add years to current date.

--- a/include/mariadb++/date_time.hpp
+++ b/include/mariadb++/date_time.hpp
@@ -179,7 +179,7 @@ class date_time : public time {
      * @param dt String containing ISO date
      * @return True on success
      */
-    bool set(const std::string& dt) override;
+    bool set(const std::string& dt);
 
     /**
      * Add years to current date.

--- a/include/mariadb++/time.hpp
+++ b/include/mariadb++/time.hpp
@@ -164,7 +164,7 @@ class time {
      *
      * @return True on success
      */
-    bool set(const std::string& t);
+    virtual bool set(const std::string& t);
 
     /**
      * Set the time from given values

--- a/include/mariadb++/time.hpp
+++ b/include/mariadb++/time.hpp
@@ -70,6 +70,11 @@ class time {
     time(const std::string& t);
 
     /**
+     * Allow proper destruction in derived classes
+     */
+    virtual ~time() = default;
+
+    /**
      * Compare this instance to given instance
      *
      * @param t Time to compare to

--- a/include/mariadb++/time.hpp
+++ b/include/mariadb++/time.hpp
@@ -164,7 +164,7 @@ class time {
      *
      * @return True on success
      */
-    virtual bool set(const std::string& t);
+    bool set(const std::string& t);
 
     /**
      * Set the time from given values

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -35,7 +35,7 @@ const std::string& connection::schema() const { return m_schema; }
 bool connection::set_schema(const std::string& schema) {
     if (!connect()) return false;
 
-    if (mysql_select_db(m_mysql, schema.c_str())) MYSQL_ERROR_RETURN_FALSE(m_mysql);
+    if (mysql_select_db(m_mysql, schema.c_str())) MYSQL_ERROR(m_mysql);
 
     m_schema = schema;
     return true;
@@ -46,7 +46,7 @@ const std::string& connection::charset() const { return m_charset; }
 bool connection::set_charset(const std::string& value) {
     if (!connect()) return false;
 
-    if (mysql_set_character_set(m_mysql, value.c_str())) MYSQL_ERROR_RETURN_FALSE(m_mysql);
+    if (mysql_set_character_set(m_mysql, value.c_str())) MYSQL_ERROR(m_mysql);
 
     m_charset = value;
     return true;
@@ -68,7 +68,7 @@ bool connection::set_auto_commit(bool auto_commit) {
 
     if (!connect()) return false;
 
-    if (mysql_autocommit(m_mysql, auto_commit)) MYSQL_ERROR_RETURN_FALSE(m_mysql);
+    if (mysql_autocommit(m_mysql, auto_commit)) MYSQL_ERROR(m_mysql);
 
     m_auto_commit = auto_commit;
     return true;
@@ -90,7 +90,7 @@ bool connection::connect() {
         if (mysql_ssl_set(m_mysql, m_account->ssl_key().c_str(),
                           m_account->ssl_certificate().c_str(), m_account->ssl_ca().c_str(),
                           m_account->ssl_ca_path().c_str(), m_account->ssl_cipher().c_str()))
-            MYSQL_ERROR_RETURN_FALSE(m_mysql);
+            MYSQL_ERROR(m_mysql);
     }
 
     //
@@ -106,7 +106,7 @@ bool connection::connect() {
             m_account->password().c_str(), nullptr, m_account->port(),
             m_account->unix_socket().empty() ? nullptr : m_account->unix_socket().c_str(),
             CLIENT_MULTI_STATEMENTS))
-        MYSQL_ERROR_RETURN_FALSE(m_mysql);
+        MYSQL_ERROR(m_mysql);
 
     if (!set_auto_commit(m_account->auto_commit())) MYSQL_ERROR_DISCONNECT(m_mysql);
 

--- a/src/date_time.cpp
+++ b/src/date_time.cpp
@@ -34,7 +34,6 @@ const u8 g_month_lengths[] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
                   << ", second - " << _second << ", millisecond - " << _millisecond              \
                   << "\nIn function: " << __FUNCTION__ << '\n';                                  \
         MARIADB_ERROR_THROW_DATE(_year, _month, _day, _hour, _minute, _second, _millisecond)     \
-        return false;                                                                            \
     }
 
 date_time::date_time(u16 year, u8 month, u8 day, u8 hour, u8 minute, u8 second, u16 millisecond) : time() {

--- a/src/private.hpp
+++ b/src/private.hpp
@@ -70,10 +70,4 @@ inline int gmtime_safe(struct tm* _tm, const time_t* _time) {
 #define STMT_ERROR(statement) \
     { STMT_ERROR_NO_BRAKET(statement) }
 
-#define STMT_ERROR_RETURN_FALSE(statement) \
-    {                                      \
-        STMT_ERROR_NO_BRAKET(statement)    \
-        return false;                      \
-    }
-
 #endif

--- a/src/private.hpp
+++ b/src/private.hpp
@@ -62,12 +62,6 @@ inline int gmtime_safe(struct tm* _tm, const time_t* _time) {
 #define MYSQL_ERROR(mysql) \
     { MYSQL_ERROR_NO_BRAKET(mysql) }
 
-#define MYSQL_ERROR_RETURN_FALSE(mysql) \
-    {                                   \
-        MYSQL_ERROR_NO_BRAKET(mysql)    \
-        return false;                   \
-    }
-
 #define STMT_ERROR_NO_BRAKET(statement)            \
     m_last_error_no = mysql_stmt_errno(statement); \
     m_last_error = mysql_stmt_error(statement);    \

--- a/src/statement.cpp
+++ b/src/statement.cpp
@@ -21,7 +21,6 @@ using namespace mariadb;
 #define STMT_ERROR_RETURN_RS(statement) \
     {                                   \
         STMT_ERROR_NO_BRAKET(statement) \
-        return rs;                      \
     }
 
 statement::statement(connection* conn, const std::string& query)

--- a/src/statement.cpp
+++ b/src/statement.cpp
@@ -45,18 +45,18 @@ void statement::set_connection(connection_ref& connection) { m_connection = conn
 
 u64 statement::execute() {
     if (m_data->m_raw_binds && mysql_stmt_bind_param(m_data->m_statement, m_data->m_raw_binds))
-        STMT_ERROR_RETURN_FALSE(m_data->m_statement);
+        STMT_ERROR(m_data->m_statement);
 
-    if (mysql_stmt_execute(m_data->m_statement)) STMT_ERROR_RETURN_FALSE(m_data->m_statement);
+    if (mysql_stmt_execute(m_data->m_statement)) STMT_ERROR(m_data->m_statement);
 
     return mysql_stmt_affected_rows(m_data->m_statement);
 }
 
 u64 statement::insert() {
     if (m_data->m_raw_binds && mysql_stmt_bind_param(m_data->m_statement, m_data->m_raw_binds))
-        STMT_ERROR_RETURN_FALSE(m_data->m_statement);
+        STMT_ERROR(m_data->m_statement);
 
-    if (mysql_stmt_execute(m_data->m_statement)) STMT_ERROR_RETURN_FALSE(m_data->m_statement);
+    if (mysql_stmt_execute(m_data->m_statement)) STMT_ERROR(m_data->m_statement);
 
     return mysql_stmt_insert_id(m_data->m_statement);
 }

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -28,7 +28,6 @@
                   << ", second - " << _second << ", millisecond - " << _millisecond           \
                   << "\nIn function: " << __FUNCTION__ << '\n';                               \
         MARIADB_ERROR_THROW_TIME(_hour, _minute, _second, _millisecond)                       \
-        return false;                                                                         \
     }
 
 mariadb::time::time(u8 hour, u8 minute, u8 second, u16 millisecond) {


### PR DESCRIPTION
Clang had some warnings on this code which I fixed. The first commit is a memory leak because of a missing virtual destructor. The second commit is a bit harder. Clang warns it is a class using a virtual function, but not a virtual destructor. Since I could not find a case in the source where a date_time object is used as a time object, I am assuming that these 2 times are not meant to be used "polymorficly", so I removed the virtual specifier. If this is a mistake, and polymophism is desired, then we should add a virtual destructor to time class.