### PR TITLE
Fix relative submodule path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "external/cmake-modules"]
 	path = external/cmake-modules
-	url = ../../viaduck/cmake-modules.git
+	url = ../cmake-modules.git


### PR DESCRIPTION
Submodule path does not need to go back two times, this works, and can also be used if someone clones cmake-modules and mariadbpp into their own namespace.