### PR TITLE
Fix result_set::column_count return type

### DIFF
--- a/include/mariadb++/result_set.hpp
+++ b/include/mariadb++/result_set.hpp
@@ -83,7 +83,7 @@ class result_set : public last_error {
      *
      * @return Count of columns
      */
-    u64 column_count() const;
+    u32 column_count() const;
 
     /**
      * Get the index of a column by column-name (case sensitive)

--- a/src/result_set.cpp
+++ b/src/result_set.cpp
@@ -89,7 +89,7 @@ result_set::~result_set() {
     }
 }
 
-u64 result_set::column_count() const { return m_field_count; }
+u32 result_set::column_count() const { return m_field_count; }
 
 value::type result_set::column_type(u32 index) const {
     if (index >= m_field_count) throw std::out_of_range("Column index out of range");


### PR DESCRIPTION
The internal `m_field_count` is a `u32`, so there is no reason to return a `u64`.