### PR TITLE
CMakeLists.txt modernization

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ test:
     script:
         - mkdir build
         - cd build
-        - cmake ../ -DMARIADBPP_TEST=ON -DTEST_HOSTNAME=mariadb -DTEST_USERNAME=$MYSQL_USER -DTEST_PASSWORD=$MYSQL_PASSWORD -DTEST_PORT=3306 -DTEST_DATABASE=$MYSQL_DATABASE -DGTEST_SRC_DIR=/usr/src/googletest/
+        - cmake ../ -DMARIADBPP_DOC=ON -DMARIADBPP_TEST=ON -DTEST_HOSTNAME=mariadb -DTEST_USERNAME=$MYSQL_USER -DTEST_PASSWORD=$MYSQL_PASSWORD -DTEST_PORT=3306 -DTEST_DATABASE=$MYSQL_DATABASE -DGTEST_SRC_DIR=/usr/src/googletest/
         - make
         - test/mariadbpp_tests             # runs gtest target
         - cmake . -DCMAKE_BUILD_TYPE=Debug

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ test:
     script:
         - mkdir build
         - cd build
-        - cmake ../ -DTEST_HOSTNAME=mariadb -DTEST_USERNAME=$MYSQL_USER -DTEST_PASSWORD=$MYSQL_PASSWORD -DTEST_PORT=3306 -DTEST_DATABASE=$MYSQL_DATABASE -DGTEST_SRC_DIR=/usr/src/googletest/
+        - cmake ../ -DMARIADBPP_TEST=ON -DTEST_HOSTNAME=mariadb -DTEST_USERNAME=$MYSQL_USER -DTEST_PASSWORD=$MYSQL_PASSWORD -DTEST_PORT=3306 -DTEST_DATABASE=$MYSQL_DATABASE -DGTEST_SRC_DIR=/usr/src/googletest/
         - make
         - test/mariadbpp_tests             # runs gtest target
         - cmake . -DCMAKE_BUILD_TYPE=Debug

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "external/cmake-modules"]
-	path = external/cmake-modules
-	url = ../cmake-modules.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
         - cd ../../
         # now build mariadbpp
         - mkdir build && cd build
-        - cmake ../ -DGTEST_SRC_DIR=/usr/src/gtest/ -DCMAKE_BUILD_TYPE=Debug -DTEST_USERNAME=$MYSQL_USER -DTEST_PASSWORD=$MYSQL_PASSWORD -DTEST_PORT=3306 -DTEST_DATABASE=$MYSQL_DATABASE && cmake --build .
+        - cmake ../ -DMARIADBPP_DOC=ON -DMARIADBPP_TEST=ON -DGTEST_SRC_DIR=/usr/src/gtest/ -DCMAKE_BUILD_TYPE=Debug -DTEST_USERNAME=$MYSQL_USER -DTEST_PASSWORD=$MYSQL_PASSWORD -DTEST_PORT=3306 -DTEST_DATABASE=$MYSQL_DATABASE && cmake --build .
         - test/mariadbpp_tests
 
       env:
@@ -57,5 +57,5 @@ before_install:
 
 script:
   - mkdir build && cd build
-  - cmake ../ -DGTEST_SRC_DIR=/usr/src/gtest/ -DCMAKE_BUILD_TYPE=Debug -DTEST_USERNAME=$MYSQL_USER -DTEST_PASSWORD=$MYSQL_PASSWORD -DTEST_PORT=3306 -DTEST_DATABASE=$MYSQL_DATABASE && cmake --build .
+  - cmake ../ -DMARIADBPP_DOC=ON -DMARIADBPP_TEST=ON -DGTEST_SRC_DIR=/usr/src/gtest/ -DCMAKE_BUILD_TYPE=Debug -DTEST_USERNAME=$MYSQL_USER -DTEST_PASSWORD=$MYSQL_PASSWORD -DTEST_PORT=3306 -DTEST_DATABASE=$MYSQL_DATABASE && cmake --build .
   - test/mariadbpp_tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ cmake_minimum_required(VERSION 3.1)
 project(mariadbclientpp LANGUAGES CXX)
 
 include(GNUInstallDirs)
-option(MARIADBPP_TEST "Build mariadbpp tests" ON)
-option(MARIADBPP_DOC "Build mariadbpp docs" ON)
+option(MARIADBPP_TEST "Build mariadbpp tests" OFF)
+option(MARIADBPP_DOC "Build mariadbpp docs" OFF)
 
 # add additional cmake modules
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,17 +4,14 @@
 #          http://www.boost.org/LICENSE_1_0.txt)
 
 cmake_minimum_required(VERSION 3.1)
-project(mariadbclientpp)
+project(mariadbclientpp LANGUAGES CXX)
 
+include(GNUInstallDirs)
 option(MARIADBPP_TEST "Build mariadbpp tests" ON)
 option(MARIADBPP_DOC "Build mariadbpp docs" ON)
 
 # add additional cmake modules
-list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/external/cmake-modules")
-
-# c++ standard
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
+list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 
 # dependencies
 find_package(MariaDBClient REQUIRED)
@@ -29,17 +26,43 @@ file(GLOB mariadbclientpp_SOURCES src/*.cpp)
 add_library(mariadbclientpp ${mariadbclientpp_SOURCES} ${mariadbclientpp_PUBLIC_HEADERS} ${mariadbclientpp_PRIVATE_HEADERS})
 
 # target options
-target_link_libraries(mariadbclientpp ${MariaDBClient_LIBRARIES} Threads::Threads)
-target_include_directories(mariadbclientpp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include ${MariaDBClient_INCLUDE_DIRS})
+target_link_libraries(mariadbclientpp MariaDBClient::MariaDBClient Threads::Threads)
+
+target_include_directories(
+	mariadbclientpp
+	PUBLIC
+	"$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
+	"$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
+
+target_compile_features(mariadbclientpp
+	PUBLIC cxx_std_11)
+
 target_compile_options(mariadbclientpp PRIVATE -Wall -Wextra)
 
 # install configuration
 install(FILES ${mariadbclientpp_PUBLIC_HEADERS} DESTINATION include/mariadb++)
 install(TARGETS mariadbclientpp
+	EXPORT mariadbclientpp_export
 	ARCHIVE DESTINATION lib
 	RUNTIME DESTINATION bin
 	LIBRARY DESTINATION lib
 )
+
+configure_file("cmake/mariadbclientpp-config.cmake.in"
+	"${CMAKE_CURRENT_BINARY_DIR}/mariadbclientpp-config.cmake" @ONLY)
+
+install(
+	EXPORT mariadbclientpp_export
+	DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/mariadbclientpp"
+	NAMESPACE "mariadbclientpp::"
+	# In this CMake config file no dependencies are considered. But since we
+	# do not use any `find_package` call here this approach is sufficient.
+	FILE mariadbclientpp-targets.cmake
+)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/mariadbclientpp-config.cmake"
+	"${PROJECT_SOURCE_DIR}/cmake/modules/FindMariaDBClient.cmake"
+	DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/mariadbclientpp")
 
 SET(CPACK_PACKAGE_DESCRIPTION_SUMMARY "MariaDB++")
 SET(CPACK_PACKAGE_VENDOR "ViaDuck")

--- a/README.md
+++ b/README.md
@@ -9,9 +9,25 @@ C++ client library for MariaDB. Uses the C connector.
 * Exceptions
 
 ## Setup
-1. Initialize Git submodules: `git submodule update --init`
-2. Install `mariadbclient` or `mysqlclient` libraries.
-3. Link against the `mariadbclientpp` CMake target in your project.
+1. Install `mariadbclient` or `mysqlclient` libraries.
+2. Build and install. E.g.
+
+```shell
+# In this project directory
+mkdir build
+cd build
+cmake ..
+make install
+```
+
+3. Use CMake to declare the dependency to `mariadbclientpp`:
+
+```cmake
+# CMakeLists.txt of your project
+find_package(mariadbclientpp REQUIRED)
+...
+target_link_libraries(yourtarget PUBLIC mariadbclientpp::mariadbclientpp)
+```
 
 ### Building tests
 Create database and user according to the information in [test/CMakeLists.txt](test/CMakeLists.txt) or adjust these values.

--- a/cmake/mariadbclientpp-config.cmake.in
+++ b/cmake/mariadbclientpp-config.cmake.in
@@ -1,0 +1,12 @@
+# Get the directory containing this file.
+get_filename_component(@PROJECT_NAME@_CURRENT_CONFIG_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(Threads REQUIRED)
+
+list(INSERT CMAKE_MODULE_PATH 0 "${@PROJECT_NAME@_CURRENT_CONFIG_DIR}/")
+find_dependency(MariaDBClient REQUIRED)
+
+# Import targets.
+include("${@PROJECT_NAME@_CURRENT_CONFIG_DIR}/@PROJECT_NAME@-targets.cmake")

--- a/cmake/modules/CodeCoverage.cmake
+++ b/cmake/modules/CodeCoverage.cmake
@@ -1,0 +1,232 @@
+# Copyright (c) 2012 - 2015, Lars Bilke
+# Copyright (c) 2016-2018, The ViaDuck Project
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without
+#    specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# CHANGES:
+#
+# 2012-01-31, Lars Bilke
+# - Enable Code Coverage
+#
+# 2013-09-17, Joakim Söderberg
+# - Added support for Clang.
+# - Some additional usage instructions.
+#
+# 2015-12-23, The ViaDuck Project
+# - Changed exclusion dirs of coverage target
+#
+# 2016-01-24, The ViaDuck Project
+# - Added additional optional parameter for specifying exclusion paths of coverage target
+#
+# 2016-03-04, The ViaDuck Project
+# - Made coverage html report more informative and fancy:
+# -- Git revision as test title
+# -- Displaying a colour legend
+# -- Branch coverage
+#
+# 2016-03-05, The ViaDuck Project
+# - Having gcov installed is not mandatory anymore when including this module
+#
+# 2017-02-04, The ViaDuck Project
+# - Bug fixes for exclusion path handling
+#
+# 2018-04-11, The ViaDuck Project
+# - Only generate coverage in debug mode
+#
+# 2018-06-06, Rayer
+# - Make this module compatible with most recent macOS provided Clang(AppleClang)
+#
+# USAGE:
+
+# 0. (Mac only) If you use Xcode 5.1 make sure to patch geninfo as described here:
+#      http://stackoverflow.com/a/22404544/80480
+#
+# 1. Copy this file into your cmake modules path.
+#
+# 2. Add the following line to your CMakeLists.txt:
+#      INCLUDE(CodeCoverage)
+#
+# 3. Set compiler flags to turn off optimization and enable coverage:
+#    SET(CMAKE_CXX_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
+#	 SET(CMAKE_C_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
+#
+# 3. Use the function SETUP_TARGET_FOR_COVERAGE to create a custom make target
+#    which runs your test executable and produces a lcov code coverage report:
+#    Example:
+#	 SETUP_TARGET_FOR_COVERAGE(
+#				my_coverage_target  # Name for custom target.
+#				test_driver         # Name of the test driver executable that runs the tests.
+#									# NOTE! This should always have a ZERO as exit code
+#									# otherwise the coverage generation will not complete.
+#				coverage            # Name of output directory.
+#				)
+#
+# 4. Build a Debug build:
+#	 cmake -DCMAKE_BUILD_TYPE=Debug ..
+#	 make
+#	 make my_coverage_target
+#
+#
+
+# Check prereqs
+FIND_PROGRAM( GCOV_PATH gcov )
+FIND_PROGRAM( LCOV_PATH lcov )
+FIND_PROGRAM( GENHTML_PATH genhtml )
+FIND_PROGRAM( GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/tests)
+
+# include git revision module
+include(GetGitRevisionDescription)
+get_git_head_revision(GIT_REFSPEC GIT_SHA1)
+
+IF(NOT CMAKE_COMPILER_IS_GNUCXX)
+    # Clang version 3.0.0 and greater now supports gcov as well.
+    MESSAGE(WARNING "Compiler is not GNU gcc! Clang Version 3.0.0 and greater supports gcov as well, but older versions don't.")
+
+    IF(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+        MESSAGE(FATAL_ERROR "Compiler is not GNU gcc! Aborting...")
+    ENDIF()
+ENDIF() # NOT CMAKE_COMPILER_IS_GNUCXX
+
+SET(CMAKE_CXX_FLAGS_COVERAGE
+        "-g -O0 --coverage -fprofile-arcs -ftest-coverage"
+        CACHE STRING "Flags used by the C++ compiler during coverage builds."
+        FORCE )
+SET(CMAKE_C_FLAGS_COVERAGE
+        "-g -O0 --coverage -fprofile-arcs -ftest-coverage"
+        CACHE STRING "Flags used by the C compiler during coverage builds."
+        FORCE )
+SET(CMAKE_EXE_LINKER_FLAGS_COVERAGE
+        ""
+        CACHE STRING "Flags used for linking binaries during coverage builds."
+        FORCE )
+SET(CMAKE_SHARED_LINKER_FLAGS_COVERAGE
+        ""
+        CACHE STRING "Flags used by the shared libraries linker during coverage builds."
+        FORCE )
+MARK_AS_ADVANCED(
+        CMAKE_CXX_FLAGS_COVERAGE
+        CMAKE_C_FLAGS_COVERAGE
+        CMAKE_EXE_LINKER_FLAGS_COVERAGE
+        CMAKE_SHARED_LINKER_FLAGS_COVERAGE )
+
+IF ( NOT (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "Coverage"))
+    MESSAGE( STATUS "Code coverage disabled in optimized (non-Debug) builds" )
+
+    FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _outputname)
+    ENDFUNCTION()
+ELSE ()
+
+
+    # Param _targetname     The name of new the custom make target
+    # Param _testrunner     The name of the target which runs the tests.
+    #						MUST return ZERO always, even on errors.
+    #						If not, no coverage report will be created!
+    # Param _outputname     lcov output is generated as _outputname.info
+    #                       HTML report is generated in _outputname/index.html
+    # Optional fourth parameter: Paths to exclude from coverage report (in list form)
+    # Optional fifth parameter is passed as arguments to _testrunner
+    #   Pass them in list form, e.g.: "-j;2" for -j 2
+    # Optional sixth parameter: 2nd test runner
+    # Optional seventh parameter is passed as arguments to 2nd test runner
+    #   Pass them in list form, e.g.: "-j;2" for -j 2
+    FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _outputname)
+
+        IF(NOT GCOV_PATH)
+            MESSAGE(FATAL_ERROR "gcov not found! Aborting...")
+        ENDIF() # NOT GCOV_PATH
+
+        IF(NOT LCOV_PATH)
+            MESSAGE(FATAL_ERROR "lcov not found! Aborting...")
+        ENDIF() # NOT LCOV_PATH
+
+        IF(NOT GENHTML_PATH)
+            MESSAGE(FATAL_ERROR "genhtml not found! Aborting...")
+        ENDIF() # NOT GENHTML_PATH
+
+        # Setup target
+        ADD_CUSTOM_TARGET(${_targetname}
+
+                # Cleanup lcov
+                ${LCOV_PATH} --rc lcov_branch_coverage=1 --directory . --zerocounters
+
+                # Run tests
+                COMMAND ${_testrunner} ${ARGV4}
+
+                COMMAND ${ARGV5} ${ARGV6}
+
+                # Capturing lcov counters and generating report
+                COMMAND ${LCOV_PATH} --rc lcov_branch_coverage=1 --directory . --capture --output-file ${_outputname}.info
+                COMMAND ${LCOV_PATH} --rc lcov_branch_coverage=1 --remove ${_outputname}.info ${ARGV3} '/usr/*' --output-file ${_outputname}.info.cleaned
+                COMMAND ${GENHTML_PATH} -t ${GIT_SHA1} --legend --branch-coverage --demangle-cpp -o ${_outputname} ${_outputname}.info.cleaned
+                COMMAND ${CMAKE_COMMAND} -E remove ${_outputname}.info ${_outputname}.info.cleaned
+
+                WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+                COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
+                )
+
+        # Show info where to find the report
+        ADD_CUSTOM_COMMAND(TARGET ${_targetname} POST_BUILD
+                COMMAND ;
+                COMMENT "Open ./${_outputname}/index.html in your browser to view the coverage report."
+                )
+
+    ENDFUNCTION() # SETUP_TARGET_FOR_COVERAGE
+
+    # Param _targetname     The name of new the custom make target
+    # Param _testrunner     The name of the target which runs the tests
+    # Param _outputname     cobertura output is generated as _outputname.xml
+    # Optional fourth parameter is passed as arguments to _testrunner
+    #   Pass them in list form, e.g.: "-j;2" for -j 2
+    FUNCTION(SETUP_TARGET_FOR_COVERAGE_COBERTURA _targetname _testrunner _outputname)
+
+        IF(NOT PYTHON_EXECUTABLE)
+            MESSAGE(FATAL_ERROR "Python not found! Aborting...")
+        ENDIF() # NOT PYTHON_EXECUTABLE
+
+        IF(NOT GCOVR_PATH)
+            MESSAGE(FATAL_ERROR "gcovr not found! Aborting...")
+        ENDIF() # NOT GCOVR_PATH
+
+        ADD_CUSTOM_TARGET(${_targetname}
+
+                # Run tests
+                ${_testrunner} ${ARGV3}
+
+                # Running gcovr
+                COMMAND ${GCOVR_PATH} -x -r ${CMAKE_SOURCE_DIR} -e '${CMAKE_SOURCE_DIR}/tests/'  -o ${_outputname}.xml
+                WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+                COMMENT "Running gcovr to produce Cobertura code coverage report."
+                )
+
+        # Show info where to find the report
+        ADD_CUSTOM_COMMAND(TARGET ${_targetname} POST_BUILD
+                COMMAND ;
+                COMMENT "Cobertura code coverage report saved in ${_outputname}.xml."
+                )
+
+    ENDFUNCTION() # SETUP_TARGET_FOR_COVERAGE_COBERTURA
+ENDIF() # NOT CMAKE_BUILD_TYPE STREQUAL "Debug"

--- a/cmake/modules/Doxygen.cmake
+++ b/cmake/modules/Doxygen.cmake
@@ -1,0 +1,41 @@
+# MIT License
+#
+# Copyright (c) 2016-2018 The ViaDuck Project
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+find_package(Doxygen)
+
+# include git revision module
+include(GetGitRevisionDescription)
+get_git_head_revision(GIT_REFSPEC GIT_SHA1)
+
+function(setup_doxygen _targetname _doxyfile)
+    if(NOT DOXYGEN_FOUND)
+        message(FATAL_ERROR "Doxygen not found! Aborting...")
+    endif()
+
+    configure_file(${_doxyfile} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
+    add_custom_target(${_targetname}
+            ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            COMMENT "Generating API documentation with Doxygen" VERBATIM
+            )
+endfunction()

--- a/cmake/modules/FindICU.cmake
+++ b/cmake/modules/FindICU.cmake
@@ -1,0 +1,715 @@
+# Copyright (c) 2011-2016, POINSOT Julien
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+# This module can find the International Components for Unicode (ICU) libraries
+#
+# Requirements:
+# - CMake >= 2.8.3 (for new version of find_package_handle_standard_args)
+#
+# The following variables will be defined for your use:
+#   - ICU_FOUND             : were all of your specified components found?
+#   - ICU_INCLUDE_DIRS      : ICU include directory
+#   - ICU_LIBRARIES         : ICU libraries
+#   - ICU_VERSION           : complete version of ICU (x.y.z)
+#   - ICU_VERSION_MAJOR     : major version of ICU
+#   - ICU_VERSION_MINOR     : minor version of ICU
+#   - ICU_VERSION_PATCH     : patch version of ICU
+#   - ICU_<COMPONENT>_FOUND : were <COMPONENT> found? (FALSE for non specified component if it is not a dependency)
+#
+# For windows or non standard installation, define ICU_ROOT_DIR variable to point to the root installation of ICU. Two ways:
+#   - run cmake with -DICU_ROOT_DIR=<PATH>
+#   - define an environment variable with the same name before running cmake
+# With cmake-gui, before pressing "Configure":
+#   1) Press "Add Entry" button
+#   2) Add a new entry defined as:
+#     - Name: ICU_ROOT_DIR
+#     - Type: choose PATH in the selection list
+#     - Press "..." button and select the root installation of ICU
+#
+# Example Usage:
+#
+#   1. Copy this file in the root of your project source directory
+#   2. Then, tell CMake to search this non-standard module in your project directory by adding to your CMakeLists.txt:
+#     set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
+#   3. Finally call find_package() once, here are some examples to pick from
+#
+#   Require ICU 4.4 or later
+#     find_package(ICU 4.4 REQUIRED)
+#
+#   if(ICU_FOUND)
+#      add_executable(myapp myapp.c)
+#      include_directories(${ICU_INCLUDE_DIRS})
+#      target_link_libraries(myapp ${ICU_LIBRARIES})
+#      # with CMake >= 3.0.0, the last two lines can be replaced by the following
+#      target_link_libraries(myapp ICU::ICU)
+#   endif(ICU_FOUND)
+
+########## <ICU finding> ##########
+
+find_package(PkgConfig QUIET)
+
+########## Private ##########
+if(NOT DEFINED ICU_PUBLIC_VAR_NS)
+    set(ICU_PUBLIC_VAR_NS "ICU")                          # Prefix for all ICU relative public variables
+endif(NOT DEFINED ICU_PUBLIC_VAR_NS)
+if(NOT DEFINED ICU_PRIVATE_VAR_NS)
+    set(ICU_PRIVATE_VAR_NS "_${ICU_PUBLIC_VAR_NS}")       # Prefix for all ICU relative internal variables
+endif(NOT DEFINED ICU_PRIVATE_VAR_NS)
+if(NOT DEFINED PC_ICU_PRIVATE_VAR_NS)
+    set(PC_ICU_PRIVATE_VAR_NS "_PC${ICU_PRIVATE_VAR_NS}") # Prefix for all pkg-config relative internal variables
+endif(NOT DEFINED PC_ICU_PRIVATE_VAR_NS)
+
+set(${ICU_PRIVATE_VAR_NS}_HINTS )
+# <deprecated>
+# for future removal
+if(DEFINED ENV{ICU_ROOT})
+    list(APPEND ${ICU_PRIVATE_VAR_NS}_HINTS "$ENV{ICU_ROOT}")
+    message(AUTHOR_WARNING "ENV{ICU_ROOT} is deprecated in favor of ENV{ICU_ROOT_DIR}")
+endif(DEFINED ENV{ICU_ROOT})
+if (DEFINED ICU_ROOT)
+    list(APPEND ${ICU_PRIVATE_VAR_NS}_HINTS "${ICU_ROOT}")
+    message(AUTHOR_WARNING "ICU_ROOT is deprecated in favor of ICU_ROOT_DIR")
+endif(DEFINED ICU_ROOT)
+# </deprecated>
+if(DEFINED ENV{ICU_ROOT_DIR})
+    list(APPEND ${ICU_PRIVATE_VAR_NS}_HINTS "$ENV{ICU_ROOT_DIR}")
+endif(DEFINED ENV{ICU_ROOT_DIR})
+if (DEFINED ICU_ROOT_DIR)
+    list(APPEND ${ICU_PRIVATE_VAR_NS}_HINTS "${ICU_ROOT_DIR}")
+endif(DEFINED ICU_ROOT_DIR)
+
+set(${ICU_PRIVATE_VAR_NS}_COMPONENTS )
+# <icu component name> <library name 1> ... <library name N>
+macro(_icu_declare_component _NAME)
+    list(APPEND ${ICU_PRIVATE_VAR_NS}_COMPONENTS ${_NAME})
+    set("${ICU_PRIVATE_VAR_NS}_COMPONENTS_${_NAME}" ${ARGN})
+endmacro(_icu_declare_component)
+
+_icu_declare_component(data icudata)
+_icu_declare_component(uc   icuuc)         # Common and Data libraries
+_icu_declare_component(i18n icui18n icuin) # Internationalization library
+_icu_declare_component(io   icuio ustdio)  # Stream and I/O Library
+_icu_declare_component(le   icule)         # Layout library
+_icu_declare_component(lx   iculx)         # Paragraph Layout library
+
+########## Public ##########
+set(${ICU_PUBLIC_VAR_NS}_FOUND FALSE)
+set(${ICU_PUBLIC_VAR_NS}_LIBRARIES )
+set(${ICU_PUBLIC_VAR_NS}_INCLUDE_DIRS )
+set(${ICU_PUBLIC_VAR_NS}_C_FLAGS "")
+set(${ICU_PUBLIC_VAR_NS}_CXX_FLAGS "")
+set(${ICU_PUBLIC_VAR_NS}_CPP_FLAGS "")
+set(${ICU_PUBLIC_VAR_NS}_C_SHARED_FLAGS "")
+set(${ICU_PUBLIC_VAR_NS}_CXX_SHARED_FLAGS "")
+set(${ICU_PUBLIC_VAR_NS}_CPP_SHARED_FLAGS "")
+
+foreach(${ICU_PRIVATE_VAR_NS}_COMPONENT ${${ICU_PRIVATE_VAR_NS}_COMPONENTS})
+    string(TOUPPER "${${ICU_PRIVATE_VAR_NS}_COMPONENT}" ${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT)
+    set("${ICU_PUBLIC_VAR_NS}_${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}_FOUND" FALSE) # may be done in the _icu_declare_component macro
+endforeach(${ICU_PRIVATE_VAR_NS}_COMPONENT)
+
+# Check components
+if(NOT ${ICU_PUBLIC_VAR_NS}_FIND_COMPONENTS) # uc required at least
+    set(${ICU_PUBLIC_VAR_NS}_FIND_COMPONENTS uc)
+else(NOT ${ICU_PUBLIC_VAR_NS}_FIND_COMPONENTS)
+    list(APPEND ${ICU_PUBLIC_VAR_NS}_FIND_COMPONENTS uc)
+    list(REMOVE_DUPLICATES ${ICU_PUBLIC_VAR_NS}_FIND_COMPONENTS)
+    foreach(${ICU_PRIVATE_VAR_NS}_COMPONENT ${${ICU_PUBLIC_VAR_NS}_FIND_COMPONENTS})
+        if(NOT DEFINED ${ICU_PRIVATE_VAR_NS}_COMPONENTS_${${ICU_PRIVATE_VAR_NS}_COMPONENT})
+            message(FATAL_ERROR "Unknown ICU component: ${${ICU_PRIVATE_VAR_NS}_COMPONENT}")
+        endif(NOT DEFINED ${ICU_PRIVATE_VAR_NS}_COMPONENTS_${${ICU_PRIVATE_VAR_NS}_COMPONENT})
+    endforeach(${ICU_PRIVATE_VAR_NS}_COMPONENT)
+endif(NOT ${ICU_PUBLIC_VAR_NS}_FIND_COMPONENTS)
+
+# if pkg-config is available check components dependencies and append `pkg-config icu-<component> --variable=prefix` to hints
+if(PKG_CONFIG_FOUND)
+    set(${ICU_PRIVATE_VAR_NS}_COMPONENTS_DUP ${${ICU_PUBLIC_VAR_NS}_FIND_COMPONENTS})
+    foreach(${ICU_PRIVATE_VAR_NS}_COMPONENT ${${ICU_PRIVATE_VAR_NS}_COMPONENTS_DUP})
+        pkg_check_modules(${PC_ICU_PRIVATE_VAR_NS} "icu-${${ICU_PRIVATE_VAR_NS}_COMPONENT}" QUIET)
+
+        if(${PC_ICU_PRIVATE_VAR_NS}_FOUND)
+            list(APPEND ${ICU_PRIVATE_VAR_NS}_HINTS ${${PC_ICU_PRIVATE_VAR_NS}_PREFIX})
+            foreach(${PC_ICU_PRIVATE_VAR_NS}_LIBRARY ${${PC_ICU_PRIVATE_VAR_NS}_LIBRARIES})
+                string(REGEX REPLACE "^icu" "" ${PC_ICU_PRIVATE_VAR_NS}_STRIPPED_LIBRARY ${${PC_ICU_PRIVATE_VAR_NS}_LIBRARY})
+                if(NOT ${PC_ICU_PRIVATE_VAR_NS}_STRIPPED_LIBRARY STREQUAL "data")
+                    list(FIND ${ICU_PUBLIC_VAR_NS}_FIND_COMPONENTS ${${PC_ICU_PRIVATE_VAR_NS}_STRIPPED_LIBRARY} ${ICU_PRIVATE_VAR_NS}_COMPONENT_INDEX)
+                    if(${ICU_PRIVATE_VAR_NS}_COMPONENT_INDEX EQUAL -1)
+                        message(WARNING "Missing component dependency: ${${PC_ICU_PRIVATE_VAR_NS}_STRIPPED_LIBRARY}. Add it to your find_package(ICU) line as COMPONENTS to fix this warning.")
+                        list(APPEND ${ICU_PUBLIC_VAR_NS}_FIND_COMPONENTS ${${PC_ICU_PRIVATE_VAR_NS}_STRIPPED_LIBRARY})
+                    endif(${ICU_PRIVATE_VAR_NS}_COMPONENT_INDEX EQUAL -1)
+                endif(NOT ${PC_ICU_PRIVATE_VAR_NS}_STRIPPED_LIBRARY STREQUAL "data")
+            endforeach(${PC_ICU_PRIVATE_VAR_NS}_LIBRARY)
+        endif(${PC_ICU_PRIVATE_VAR_NS}_FOUND)
+    endforeach(${ICU_PRIVATE_VAR_NS}_COMPONENT)
+endif(PKG_CONFIG_FOUND)
+# list(APPEND ${ICU_PRIVATE_VAR_NS}_HINTS ENV ICU_ROOT_DIR)
+# message("${ICU_PRIVATE_VAR_NS}_HINTS = ${${ICU_PRIVATE_VAR_NS}_HINTS}")
+
+# Includes
+find_path(
+    ${ICU_PUBLIC_VAR_NS}_INCLUDE_DIR
+    NAMES unicode/utypes.h utypes.h
+    HINTS ${${ICU_PRIVATE_VAR_NS}_HINTS}
+    PATH_SUFFIXES "include"
+    DOC "Include directories for ICU"
+)
+
+if(${ICU_PUBLIC_VAR_NS}_INCLUDE_DIR)
+    ########## <part to keep synced with tests/version/CMakeLists.txt> ##########
+    if(EXISTS "${${ICU_PUBLIC_VAR_NS}_INCLUDE_DIR}/unicode/uvernum.h") # ICU >= 4.4
+        file(READ "${${ICU_PUBLIC_VAR_NS}_INCLUDE_DIR}/unicode/uvernum.h" ${ICU_PRIVATE_VAR_NS}_VERSION_HEADER_CONTENTS)
+    elseif(EXISTS "${${ICU_PUBLIC_VAR_NS}_INCLUDE_DIR}/unicode/uversion.h") # ICU [2;4.4[
+        file(READ "${${ICU_PUBLIC_VAR_NS}_INCLUDE_DIR}/unicode/uversion.h" ${ICU_PRIVATE_VAR_NS}_VERSION_HEADER_CONTENTS)
+    elseif(EXISTS "${${ICU_PUBLIC_VAR_NS}_INCLUDE_DIR}/unicode/utypes.h") # ICU [1.4;2[
+        file(READ "${${ICU_PUBLIC_VAR_NS}_INCLUDE_DIR}/unicode/utypes.h" ${ICU_PRIVATE_VAR_NS}_VERSION_HEADER_CONTENTS)
+    elseif(EXISTS "${${ICU_PUBLIC_VAR_NS}_INCLUDE_DIR}/utypes.h") # ICU 1.3
+        file(READ "${${ICU_PUBLIC_VAR_NS}_INCLUDE_DIR}/utypes.h" ${ICU_PRIVATE_VAR_NS}_VERSION_HEADER_CONTENTS)
+    else()
+        message(FATAL_ERROR "ICU version header not found")
+    endif()
+
+    if(${ICU_PRIVATE_VAR_NS}_VERSION_HEADER_CONTENTS MATCHES ".*# *define *ICU_VERSION *\"([0-9]+)\".*") # ICU 1.3
+        # [1.3;1.4[ as #define ICU_VERSION "3" (no patch version, ie all 1.3.X versions will be detected as 1.3.0)
+        set(${ICU_PUBLIC_VAR_NS}_VERSION_MAJOR "1")
+        set(${ICU_PUBLIC_VAR_NS}_VERSION_MINOR "${CMAKE_MATCH_1}")
+        set(${ICU_PUBLIC_VAR_NS}_VERSION_PATCH "0")
+    elseif(${ICU_PRIVATE_VAR_NS}_VERSION_HEADER_CONTENTS MATCHES ".*# *define *U_ICU_VERSION_MAJOR_NUM *([0-9]+).*")
+        #
+        # Since version 4.9.1, ICU release version numbering was totaly changed, see:
+        # - http://site.icu-project.org/download/49
+        # - http://userguide.icu-project.org/design#TOC-Version-Numbers-in-ICU
+        #
+        set(${ICU_PUBLIC_VAR_NS}_VERSION_MAJOR "${CMAKE_MATCH_1}")
+        string(REGEX REPLACE ".*# *define *U_ICU_VERSION_MINOR_NUM *([0-9]+).*" "\\1" ${ICU_PUBLIC_VAR_NS}_VERSION_MINOR "${${ICU_PRIVATE_VAR_NS}_VERSION_HEADER_CONTENTS}")
+        string(REGEX REPLACE ".*# *define *U_ICU_VERSION_PATCHLEVEL_NUM *([0-9]+).*" "\\1" ${ICU_PUBLIC_VAR_NS}_VERSION_PATCH "${${ICU_PRIVATE_VAR_NS}_VERSION_HEADER_CONTENTS}")
+    elseif(${ICU_PRIVATE_VAR_NS}_VERSION_HEADER_CONTENTS MATCHES ".*# *define *U_ICU_VERSION *\"(([0-9]+)(\\.[0-9]+)*)\".*") # ICU [1.4;1.8[
+        # [1.4;1.8[ as #define U_ICU_VERSION "1.4.1.2" but it seems that some 1.4.[12](?:\.\d)? have releasing error and appears as 1.4.0
+        set(${ICU_PRIVATE_VAR_NS}_FULL_VERSION "${CMAKE_MATCH_1}") # copy CMAKE_MATCH_1, no longer valid on the following if
+        if(${ICU_PRIVATE_VAR_NS}_FULL_VERSION MATCHES "^([0-9]+)\\.([0-9]+)$")
+            set(${ICU_PUBLIC_VAR_NS}_VERSION_MAJOR "${CMAKE_MATCH_1}")
+            set(${ICU_PUBLIC_VAR_NS}_VERSION_MINOR "${CMAKE_MATCH_2}")
+            set(${ICU_PUBLIC_VAR_NS}_VERSION_PATCH "0")
+        elseif(${ICU_PRIVATE_VAR_NS}_FULL_VERSION MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)")
+            set(${ICU_PUBLIC_VAR_NS}_VERSION_MAJOR "${CMAKE_MATCH_1}")
+            set(${ICU_PUBLIC_VAR_NS}_VERSION_MINOR "${CMAKE_MATCH_2}")
+            set(${ICU_PUBLIC_VAR_NS}_VERSION_PATCH "${CMAKE_MATCH_3}")
+        endif()
+    else()
+        message(FATAL_ERROR "failed to detect ICU version")
+    endif()
+    set(${ICU_PUBLIC_VAR_NS}_VERSION "${${ICU_PUBLIC_VAR_NS}_VERSION_MAJOR}.${${ICU_PUBLIC_VAR_NS}_VERSION_MINOR}.${${ICU_PUBLIC_VAR_NS}_VERSION_PATCH}")
+    ########## </part to keep synced with tests/version/CMakeLists.txt> ##########
+endif(${ICU_PUBLIC_VAR_NS}_INCLUDE_DIR)
+
+# Check libraries
+if(MSVC)
+    include(SelectLibraryConfigurations)
+endif(MSVC)
+foreach(${ICU_PRIVATE_VAR_NS}_COMPONENT ${${ICU_PUBLIC_VAR_NS}_FIND_COMPONENTS})
+    string(TOUPPER "${${ICU_PRIVATE_VAR_NS}_COMPONENT}" ${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT)
+    if(MSVC)
+        set(${ICU_PRIVATE_VAR_NS}_POSSIBLE_RELEASE_NAMES )
+        set(${ICU_PRIVATE_VAR_NS}_POSSIBLE_DEBUG_NAMES )
+        foreach(${ICU_PRIVATE_VAR_NS}_BASE_NAME ${${ICU_PRIVATE_VAR_NS}_COMPONENTS_${${ICU_PRIVATE_VAR_NS}_COMPONENT}})
+            list(APPEND ${ICU_PRIVATE_VAR_NS}_POSSIBLE_RELEASE_NAMES "${${ICU_PRIVATE_VAR_NS}_BASE_NAME}")
+            list(APPEND ${ICU_PRIVATE_VAR_NS}_POSSIBLE_DEBUG_NAMES "${${ICU_PRIVATE_VAR_NS}_BASE_NAME}d")
+            list(APPEND ${ICU_PRIVATE_VAR_NS}_POSSIBLE_RELEASE_NAMES "${${ICU_PRIVATE_VAR_NS}_BASE_NAME}${${ICU_PUBLIC_VAR_NS}_VERSION_MAJOR}${${ICU_PUBLIC_VAR_NS}_VERSION_MINOR}")
+            list(APPEND ${ICU_PRIVATE_VAR_NS}_POSSIBLE_DEBUG_NAMES "${${ICU_PRIVATE_VAR_NS}_BASE_NAME}${${ICU_PUBLIC_VAR_NS}_VERSION_MAJOR}${${ICU_PUBLIC_VAR_NS}_VERSION_MINOR}d")
+        endforeach(${ICU_PRIVATE_VAR_NS}_BASE_NAME)
+
+        find_library(
+            ${ICU_PUBLIC_VAR_NS}_${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}_LIBRARY_RELEASE
+            NAMES ${${ICU_PRIVATE_VAR_NS}_POSSIBLE_RELEASE_NAMES}
+            HINTS ${${ICU_PRIVATE_VAR_NS}_HINTS}
+            DOC "Release library for ICU ${${ICU_PRIVATE_VAR_NS}_COMPONENT} component"
+        )
+        find_library(
+            ${ICU_PUBLIC_VAR_NS}_${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}_LIBRARY_DEBUG
+            NAMES ${${ICU_PRIVATE_VAR_NS}_POSSIBLE_DEBUG_NAMES}
+            HINTS ${${ICU_PRIVATE_VAR_NS}_HINTS}
+            DOC "Debug library for ICU ${${ICU_PRIVATE_VAR_NS}_COMPONENT} component"
+        )
+
+        select_library_configurations("${ICU_PUBLIC_VAR_NS}_${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}")
+        list(APPEND ${ICU_PUBLIC_VAR_NS}_LIBRARY ${${ICU_PUBLIC_VAR_NS}_${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}_LIBRARY})
+    else(MSVC)
+        find_library(
+            ${ICU_PUBLIC_VAR_NS}_${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}_LIBRARY
+            NAMES ${${ICU_PRIVATE_VAR_NS}_COMPONENTS_${${ICU_PRIVATE_VAR_NS}_COMPONENT}}
+            PATHS ${${ICU_PRIVATE_VAR_NS}_HINTS}
+            DOC "Library for ICU ${${ICU_PRIVATE_VAR_NS}_COMPONENT} component"
+        )
+
+        if(${ICU_PUBLIC_VAR_NS}_${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}_LIBRARY)
+            set("${ICU_PUBLIC_VAR_NS}_${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}_FOUND" TRUE)
+            list(APPEND ${ICU_PUBLIC_VAR_NS}_LIBRARY ${${ICU_PUBLIC_VAR_NS}_${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}_LIBRARY})
+        endif(${ICU_PUBLIC_VAR_NS}_${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}_LIBRARY)
+    endif(MSVC)
+endforeach(${ICU_PRIVATE_VAR_NS}_COMPONENT)
+
+# Try to find out compiler flags
+find_program(${ICU_PUBLIC_VAR_NS}_CONFIG_EXECUTABLE icu-config HINTS ${${ICU_PRIVATE_VAR_NS}_HINTS})
+if(${ICU_PUBLIC_VAR_NS}_CONFIG_EXECUTABLE)
+    execute_process(COMMAND ${${ICU_PUBLIC_VAR_NS}_CONFIG_EXECUTABLE} --cflags OUTPUT_VARIABLE ${ICU_PUBLIC_VAR_NS}_C_FLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process(COMMAND ${${ICU_PUBLIC_VAR_NS}_CONFIG_EXECUTABLE} --cxxflags OUTPUT_VARIABLE ${ICU_PUBLIC_VAR_NS}_CXX_FLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process(COMMAND ${${ICU_PUBLIC_VAR_NS}_CONFIG_EXECUTABLE} --cppflags OUTPUT_VARIABLE ${ICU_PUBLIC_VAR_NS}_CPP_FLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    execute_process(COMMAND ${${ICU_PUBLIC_VAR_NS}_CONFIG_EXECUTABLE} --cflags-dynamic OUTPUT_VARIABLE ${ICU_PUBLIC_VAR_NS}_C_SHARED_FLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process(COMMAND ${${ICU_PUBLIC_VAR_NS}_CONFIG_EXECUTABLE} --cxxflags-dynamic OUTPUT_VARIABLE ${ICU_PUBLIC_VAR_NS}_CXX_SHARED_FLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process(COMMAND ${${ICU_PUBLIC_VAR_NS}_CONFIG_EXECUTABLE} --cppflags-dynamic OUTPUT_VARIABLE ${ICU_PUBLIC_VAR_NS}_CPP_SHARED_FLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif(${ICU_PUBLIC_VAR_NS}_CONFIG_EXECUTABLE)
+
+# Check find_package arguments
+include(FindPackageHandleStandardArgs)
+if(${ICU_PUBLIC_VAR_NS}_FIND_REQUIRED AND NOT ${ICU_PUBLIC_VAR_NS}_FIND_QUIETLY)
+    find_package_handle_standard_args(
+        ${ICU_PUBLIC_VAR_NS}
+        REQUIRED_VARS ${ICU_PUBLIC_VAR_NS}_LIBRARY ${ICU_PUBLIC_VAR_NS}_INCLUDE_DIR
+        VERSION_VAR ${ICU_PUBLIC_VAR_NS}_VERSION
+    )
+else(${ICU_PUBLIC_VAR_NS}_FIND_REQUIRED AND NOT ${ICU_PUBLIC_VAR_NS}_FIND_QUIETLY)
+    find_package_handle_standard_args(${ICU_PUBLIC_VAR_NS} "Could NOT find ICU" ${ICU_PUBLIC_VAR_NS}_LIBRARY ${ICU_PUBLIC_VAR_NS}_INCLUDE_DIR)
+endif(${ICU_PUBLIC_VAR_NS}_FIND_REQUIRED AND NOT ${ICU_PUBLIC_VAR_NS}_FIND_QUIETLY)
+
+if(${ICU_PUBLIC_VAR_NS}_FOUND)
+    # <deprecated>
+    # for compatibility with previous versions, alias old ICU_(MAJOR|MINOR|PATCH)_VERSION to ICU_VERSION_$1
+    set(${ICU_PUBLIC_VAR_NS}_MAJOR_VERSION ${${ICU_PUBLIC_VAR_NS}_VERSION_MAJOR})
+    set(${ICU_PUBLIC_VAR_NS}_MINOR_VERSION ${${ICU_PUBLIC_VAR_NS}_VERSION_MINOR})
+    set(${ICU_PUBLIC_VAR_NS}_PATCH_VERSION ${${ICU_PUBLIC_VAR_NS}_VERSION_PATCH})
+    # </deprecated>
+    set(${ICU_PUBLIC_VAR_NS}_LIBRARIES ${${ICU_PUBLIC_VAR_NS}_LIBRARY})
+    set(${ICU_PUBLIC_VAR_NS}_INCLUDE_DIRS ${${ICU_PUBLIC_VAR_NS}_INCLUDE_DIR})
+
+    if(NOT CMAKE_VERSION VERSION_LESS "3.0.0")
+        if(NOT TARGET ICU::ICU)
+            add_library(ICU::ICU INTERFACE IMPORTED)
+        endif(NOT TARGET ICU::ICU)
+        set_target_properties(ICU::ICU PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${${ICU_PUBLIC_VAR_NS}_INCLUDE_DIR}")
+        foreach(${ICU_PRIVATE_VAR_NS}_COMPONENT ${${ICU_PUBLIC_VAR_NS}_FIND_COMPONENTS})
+            string(TOUPPER "${${ICU_PRIVATE_VAR_NS}_COMPONENT}" ${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT)
+            add_library("ICU::${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}" UNKNOWN IMPORTED)
+            if(${ICU_PUBLIC_VAR_NS}_${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}_LIBRARY_RELEASE)
+                set_property(TARGET "ICU::${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}" APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+                set_target_properties("ICU::${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}" PROPERTIES IMPORTED_LOCATION_RELEASE "${${ICU_PUBLIC_VAR_NS}_${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}_LIBRARY_RELEASE}")
+            endif(${ICU_PUBLIC_VAR_NS}_${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}_LIBRARY_RELEASE)
+            if(${ICU_PUBLIC_VAR_NS}_${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}_LIBRARY_DEBUG)
+                set_property(TARGET "ICU::${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}" APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+                set_target_properties("ICU::${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}" PROPERTIES IMPORTED_LOCATION_DEBUG "${${ICU_PUBLIC_VAR_NS}_${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}_LIBRARY_DEBUG}")
+            endif(${ICU_PUBLIC_VAR_NS}_${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}_LIBRARY_DEBUG)
+            if(${ICU_PUBLIC_VAR_NS}_${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}_LIBRARY)
+                set_target_properties("ICU::${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}" PROPERTIES IMPORTED_LOCATION "${${ICU_PUBLIC_VAR_NS}_${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}_LIBRARY}")
+            endif(${ICU_PUBLIC_VAR_NS}_${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}_LIBRARY)
+            set_property(TARGET ICU::ICU APPEND PROPERTY INTERFACE_LINK_LIBRARIES "ICU::${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}")
+#             set_target_properties("ICU::${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}" PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${${ICU_PUBLIC_VAR_NS}_INCLUDE_DIR}")
+        endforeach(${ICU_PRIVATE_VAR_NS}_COMPONENT)
+    endif(NOT CMAKE_VERSION VERSION_LESS "3.0.0")
+endif(${ICU_PUBLIC_VAR_NS}_FOUND)
+
+mark_as_advanced(
+    ${ICU_PUBLIC_VAR_NS}_INCLUDE_DIR
+    ${ICU_PUBLIC_VAR_NS}_LIBRARY
+)
+
+########## </ICU finding> ##########
+
+########## <resource bundle support> ##########
+
+########## Private ##########
+function(_icu_extract_locale_from_rb _BUNDLE_SOURCE _RETURN_VAR_NAME)
+    file(READ "${_BUNDLE_SOURCE}" _BUNDLE_CONTENTS)
+    string(REGEX REPLACE "//[^\n]*\n" "" _BUNDLE_CONTENTS_WITHOUT_COMMENTS ${_BUNDLE_CONTENTS})
+    string(REGEX REPLACE "[ \t\n]" "" _BUNDLE_CONTENTS_WITHOUT_COMMENTS_AND_SPACES ${_BUNDLE_CONTENTS_WITHOUT_COMMENTS})
+    string(REGEX MATCH "^([a-zA-Z_-]+)(:table)?{" LOCALE_FOUND ${_BUNDLE_CONTENTS_WITHOUT_COMMENTS_AND_SPACES})
+    set("${_RETURN_VAR_NAME}" "${CMAKE_MATCH_1}" PARENT_SCOPE)
+endfunction(_icu_extract_locale_from_rb)
+
+########## Public ##########
+
+#
+# Prototype:
+#   icu_generate_resource_bundle([NAME <name>] [PACKAGE] [DESTINATION <location>] [FILES <list of files>])
+#
+# Common arguments:
+#   - NAME <name>                      : name of output package and to create dummy targets
+#   - FILES <file 1> ... <file N>      : list of resource bundles sources
+#   - DEPENDS <target1> ... <target N> : required to package as library (shared or static), a list of cmake parent targets to link to
+#                                        Note: only (PREVIOUSLY DECLARED) add_executable and add_library as dependencies
+#   - DESTINATION <location>           : optional, directory where to install final binary file(s)
+#   - FORMAT <name>                    : optional, one of none (ICU4C binary format, default), java (plain java) or xliff (XML), see below
+#
+# Arguments depending on FORMAT:
+#   - none (default):
+#       * PACKAGE     : if present, package all resource bundles together. Default is to stop after building individual *.res files
+#       * TYPE <name> : one of :
+#           + common or archive (default) : archive all ressource bundles into a single .dat file
+#           + library or dll              : assemble all ressource bundles into a separate and loadable library (.dll/.so)
+#           + static                      : integrate all ressource bundles to targets designed by DEPENDS parameter (as a static library)
+#       * NO_SHARED_FLAGS                 : only with TYPE in ['library', 'dll', 'static'], do not append ICU_C(XX)_SHARED_FLAGS to targets given as DEPENDS argument
+#   - JAVA:
+#       * BUNDLE <name> : required, prefix for generated classnames
+#   - XLIFF:
+#       (none)
+#
+
+#
+# For an archive, the idea is to generate the following dependencies:
+#
+#   root.txt => root.res \
+#                        |
+#   en.txt   => en.res   |
+#                        | => pkglist.txt => application.dat
+#   fr.txt   => fr.res   |
+#                        |
+#   and so on            /
+#
+# Lengend: 'A => B' means B depends on A
+#
+# Steps (correspond to arrows):
+#   1) genrb (from .txt to .res)
+#   2) generate a file text (pkglist.txt) with all .res files to put together
+#   3) build final archive (from *.res/pkglist.txt to .dat)
+#
+
+function(icu_generate_resource_bundle)
+
+    ##### <check for pkgdata/genrb availability> #####
+    find_program(${ICU_PUBLIC_VAR_NS}_GENRB_EXECUTABLE genrb HINTS ${${ICU_PRIVATE_VAR_NS}_HINTS})
+    find_program(${ICU_PUBLIC_VAR_NS}_PKGDATA_EXECUTABLE pkgdata HINTS ${${ICU_PRIVATE_VAR_NS}_HINTS})
+
+    if(NOT ${ICU_PUBLIC_VAR_NS}_GENRB_EXECUTABLE)
+        message(FATAL_ERROR "genrb not found")
+    endif(NOT ${ICU_PUBLIC_VAR_NS}_GENRB_EXECUTABLE)
+    if(NOT ${ICU_PUBLIC_VAR_NS}_PKGDATA_EXECUTABLE)
+        message(FATAL_ERROR "pkgdata not found")
+    endif(NOT ${ICU_PUBLIC_VAR_NS}_PKGDATA_EXECUTABLE)
+    ##### </check for pkgdata/genrb availability> #####
+
+    ##### <constants> #####
+    set(TARGET_SEPARATOR "+")
+    set(__FUNCTION__ "icu_generate_resource_bundle")
+    set(PACKAGE_TARGET_PREFIX "ICU${TARGET_SEPARATOR}PKG")
+    set(RESOURCE_TARGET_PREFIX "ICU${TARGET_SEPARATOR}RB")
+    ##### </constants> #####
+
+    ##### <hash constants> #####
+    # filename extension of built resource bundle (without dot)
+    set(BUNDLES__SUFFIX "res")
+    set(BUNDLES_JAVA_SUFFIX "java")
+    set(BUNDLES_XLIFF_SUFFIX "xlf")
+    # alias: none (default) = common = archive ; dll = library ; static
+    set(PKGDATA__ALIAS "")
+    set(PKGDATA_COMMON_ALIAS "")
+    set(PKGDATA_ARCHIVE_ALIAS "")
+    set(PKGDATA_DLL_ALIAS "LIBRARY")
+    set(PKGDATA_LIBRARY_ALIAS "LIBRARY")
+    set(PKGDATA_STATIC_ALIAS "STATIC")
+    # filename prefix of built package
+    set(PKGDATA__PREFIX "")
+    set(PKGDATA_LIBRARY_PREFIX "${CMAKE_SHARED_LIBRARY_PREFIX}")
+    set(PKGDATA_STATIC_PREFIX "${CMAKE_STATIC_LIBRARY_PREFIX}")
+    # filename extension of built package (with dot)
+    set(PKGDATA__SUFFIX ".dat")
+    set(PKGDATA_LIBRARY_SUFFIX "${CMAKE_SHARED_LIBRARY_SUFFIX}")
+    set(PKGDATA_STATIC_SUFFIX "${CMAKE_STATIC_LIBRARY_SUFFIX}")
+    # pkgdata option mode specific
+    set(PKGDATA__OPTIONS "-m" "common")
+    set(PKGDATA_STATIC_OPTIONS "-m" "static")
+    set(PKGDATA_LIBRARY_OPTIONS "-m" "library")
+    # cmake library type for output package
+    set(PKGDATA_LIBRARY__TYPE "")
+    set(PKGDATA_LIBRARY_STATIC_TYPE STATIC)
+    set(PKGDATA_LIBRARY_LIBRARY_TYPE SHARED)
+    ##### </hash constants> #####
+
+    include(CMakeParseArguments)
+    cmake_parse_arguments(
+        PARSED_ARGS # output variable name
+        # options (true/false) (default value: false)
+        "PACKAGE;NO_SHARED_FLAGS"
+        # univalued parameters (default value: "")
+        "NAME;DESTINATION;TYPE;FORMAT;BUNDLE"
+        # multivalued parameters (default value: "")
+        "FILES;DEPENDS"
+        ${ARGN}
+    )
+
+    # assert(${PARSED_ARGS_NAME} != "")
+    if(NOT PARSED_ARGS_NAME)
+        message(FATAL_ERROR "${__FUNCTION__}(): no name given, NAME parameter missing")
+    endif(NOT PARSED_ARGS_NAME)
+
+    # assert(length(PARSED_ARGS_FILES) > 0)
+    list(LENGTH PARSED_ARGS_FILES PARSED_ARGS_FILES_LEN)
+    if(PARSED_ARGS_FILES_LEN LESS 1)
+        message(FATAL_ERROR "${__FUNCTION__}() expects at least 1 resource bundle as FILES argument, 0 given")
+    endif(PARSED_ARGS_FILES_LEN LESS 1)
+
+    string(TOUPPER "${PARSED_ARGS_FORMAT}" UPPER_FORMAT)
+    # assert(${UPPER_FORMAT} in ['', 'java', 'xlif'])
+    if(NOT DEFINED BUNDLES_${UPPER_FORMAT}_SUFFIX)
+        message(FATAL_ERROR "${__FUNCTION__}(): unknown FORMAT '${PARSED_ARGS_FORMAT}'")
+    endif(NOT DEFINED BUNDLES_${UPPER_FORMAT}_SUFFIX)
+
+    if(UPPER_FORMAT STREQUAL "JAVA")
+        # assert(${PARSED_ARGS_BUNDLE} != "")
+        if(NOT PARSED_ARGS_BUNDLE)
+            message(FATAL_ERROR "${__FUNCTION__}(): java bundle name expected, BUNDLE parameter missing")
+        endif(NOT PARSED_ARGS_BUNDLE)
+    endif(UPPER_FORMAT STREQUAL "JAVA")
+
+    if(PARSED_ARGS_PACKAGE)
+        # assert(${PARSED_ARGS_FORMAT} == "")
+        if(PARSED_ARGS_FORMAT)
+            message(FATAL_ERROR "${__FUNCTION__}(): packaging is only supported for binary format, not xlif neither java outputs")
+        endif(PARSED_ARGS_FORMAT)
+
+        string(TOUPPER "${PARSED_ARGS_TYPE}" UPPER_MODE)
+        # assert(${UPPER_MODE} in ['', 'common', 'archive', 'dll', library'])
+        if(NOT DEFINED PKGDATA_${UPPER_MODE}_ALIAS)
+            message(FATAL_ERROR "${__FUNCTION__}(): unknown TYPE '${PARSED_ARGS_TYPE}'")
+        else(NOT DEFINED PKGDATA_${UPPER_MODE}_ALIAS)
+            set(TYPE "${PKGDATA_${UPPER_MODE}_ALIAS}")
+        endif(NOT DEFINED PKGDATA_${UPPER_MODE}_ALIAS)
+
+        # Package name: strip file extension if present
+        get_filename_component(PACKAGE_NAME_WE ${PARSED_ARGS_NAME} NAME_WE)
+        # Target name to build package
+        set(PACKAGE_TARGET_NAME "${PACKAGE_TARGET_PREFIX}${TARGET_SEPARATOR}${PACKAGE_NAME_WE}")
+        # Target name to build intermediate list file
+        set(PACKAGE_LIST_TARGET_NAME "${PACKAGE_TARGET_NAME}${TARGET_SEPARATOR}PKGLIST")
+        # Directory (absolute) to set as "current directory" for genrb (does not include package directory, -p)
+        # We make our "cook" there to prevent any conflict
+        if(DEFINED CMAKE_PLATFORM_ROOT_BIN) # CMake < 2.8.10
+            set(RESOURCE_GENRB_CHDIR_DIR "${CMAKE_PLATFORM_ROOT_BIN}/${PACKAGE_TARGET_NAME}.dir/")
+        else(DEFINED CMAKE_PLATFORM_ROOT_BIN) # CMake >= 2.8.10
+            set(RESOURCE_GENRB_CHDIR_DIR "${CMAKE_PLATFORM_INFO_DIR}/${PACKAGE_TARGET_NAME}.dir/")
+        endif(DEFINED CMAKE_PLATFORM_ROOT_BIN)
+        # Directory (absolute) where resource bundles are built: concatenation of RESOURCE_GENRB_CHDIR_DIR and package name
+        set(RESOURCE_OUTPUT_DIR "${RESOURCE_GENRB_CHDIR_DIR}/${PACKAGE_NAME_WE}/")
+        # Output (relative) path for built package
+        if(MSVC AND TYPE STREQUAL PKGDATA_LIBRARY_ALIAS)
+            set(PACKAGE_OUTPUT_PATH "${RESOURCE_GENRB_CHDIR_DIR}/${PACKAGE_NAME_WE}/${PKGDATA_${TYPE}_PREFIX}${PACKAGE_NAME_WE}${PKGDATA_${TYPE}_SUFFIX}")
+        else(MSVC AND TYPE STREQUAL PKGDATA_LIBRARY_ALIAS)
+            set(PACKAGE_OUTPUT_PATH "${RESOURCE_GENRB_CHDIR_DIR}/${PKGDATA_${TYPE}_PREFIX}${PACKAGE_NAME_WE}${PKGDATA_${TYPE}_SUFFIX}")
+        endif(MSVC AND TYPE STREQUAL PKGDATA_LIBRARY_ALIAS)
+        # Output (absolute) path for the list file
+        set(PACKAGE_LIST_OUTPUT_PATH "${RESOURCE_GENRB_CHDIR_DIR}/pkglist.txt")
+
+        file(MAKE_DIRECTORY "${RESOURCE_OUTPUT_DIR}")
+    else(PARSED_ARGS_PACKAGE)
+        set(RESOURCE_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/")
+#         set(RESOURCE_GENRB_CHDIR_DIR "UNUSED")
+    endif(PARSED_ARGS_PACKAGE)
+
+    set(TARGET_RESOURCES )
+    set(COMPILED_RESOURCES_PATH )
+    set(COMPILED_RESOURCES_BASENAME )
+    foreach(RESOURCE_SOURCE ${PARSED_ARGS_FILES})
+        _icu_extract_locale_from_rb(${RESOURCE_SOURCE} RESOURCE_NAME_WE)
+        get_filename_component(SOURCE_BASENAME ${RESOURCE_SOURCE} NAME)
+        get_filename_component(ABSOLUTE_SOURCE ${RESOURCE_SOURCE} ABSOLUTE)
+
+        if(UPPER_FORMAT STREQUAL "XLIFF")
+            if(RESOURCE_NAME_WE STREQUAL "root")
+                set(XLIFF_LANGUAGE "en")
+            else(RESOURCE_NAME_WE STREQUAL "root")
+                string(REGEX REPLACE "[^a-z].*$" "" XLIFF_LANGUAGE "${RESOURCE_NAME_WE}")
+            endif(RESOURCE_NAME_WE STREQUAL "root")
+        endif(UPPER_FORMAT STREQUAL "XLIFF")
+
+        ##### <templates> #####
+        set(RESOURCE_TARGET_NAME "${RESOURCE_TARGET_PREFIX}${TARGET_SEPARATOR}${PARSED_ARGS_NAME}${TARGET_SEPARATOR}${RESOURCE_NAME_WE}")
+
+        set(RESOURCE_OUTPUT__PATH "${RESOURCE_NAME_WE}.res")
+        if(RESOURCE_NAME_WE STREQUAL "root")
+            set(RESOURCE_OUTPUT_JAVA_PATH "${PARSED_ARGS_BUNDLE}.java")
+        else(RESOURCE_NAME_WE STREQUAL "root")
+            set(RESOURCE_OUTPUT_JAVA_PATH "${PARSED_ARGS_BUNDLE}_${RESOURCE_NAME_WE}.java")
+        endif(RESOURCE_NAME_WE STREQUAL "root")
+        set(RESOURCE_OUTPUT_XLIFF_PATH "${RESOURCE_NAME_WE}.xlf")
+
+        set(GENRB__OPTIONS "")
+        set(GENRB_JAVA_OPTIONS "-j" "-b" "${PARSED_ARGS_BUNDLE}")
+        set(GENRB_XLIFF_OPTIONS "-x" "-l" "${XLIFF_LANGUAGE}")
+        ##### </templates> #####
+
+        # build <locale>.txt from <locale>.res
+        if(PARSED_ARGS_PACKAGE)
+            add_custom_command(
+                OUTPUT "${RESOURCE_OUTPUT_DIR}${RESOURCE_OUTPUT_${UPPER_FORMAT}_PATH}"
+                COMMAND ${CMAKE_COMMAND} -E chdir ${RESOURCE_GENRB_CHDIR_DIR} ${${ICU_PUBLIC_VAR_NS}_GENRB_EXECUTABLE} ${GENRB_${UPPER_FORMAT}_OPTIONS} -d ${PACKAGE_NAME_WE} ${ABSOLUTE_SOURCE}
+                DEPENDS ${RESOURCE_SOURCE}
+            )
+        else(PARSED_ARGS_PACKAGE)
+            add_custom_command(
+                OUTPUT "${RESOURCE_OUTPUT_DIR}${RESOURCE_OUTPUT_${UPPER_FORMAT}_PATH}"
+                COMMAND ${${ICU_PUBLIC_VAR_NS}_GENRB_EXECUTABLE} ${GENRB_${UPPER_FORMAT}_OPTIONS} -d ${RESOURCE_OUTPUT_DIR} ${ABSOLUTE_SOURCE}
+                DEPENDS ${RESOURCE_SOURCE}
+            )
+        endif(PARSED_ARGS_PACKAGE)
+        # dummy target (ICU+RB+<name>+<locale>) for each locale to build the <locale>.res file from its <locale>.txt by the add_custom_command above
+        add_custom_target(
+            "${RESOURCE_TARGET_NAME}" ALL
+            COMMENT ""
+            DEPENDS "${RESOURCE_OUTPUT_DIR}${RESOURCE_OUTPUT_${UPPER_FORMAT}_PATH}"
+            SOURCES ${RESOURCE_SOURCE}
+        )
+
+        if(PARSED_ARGS_DESTINATION AND NOT PARSED_ARGS_PACKAGE)
+            install(FILES "${RESOURCE_OUTPUT_DIR}${RESOURCE_OUTPUT_${UPPER_FORMAT}_PATH}" DESTINATION ${PARSED_ARGS_DESTINATION} PERMISSIONS OWNER_READ GROUP_READ WORLD_READ)
+        endif(PARSED_ARGS_DESTINATION AND NOT PARSED_ARGS_PACKAGE)
+
+        list(APPEND TARGET_RESOURCES "${RESOURCE_TARGET_NAME}")
+        list(APPEND COMPILED_RESOURCES_PATH "${RESOURCE_OUTPUT_DIR}${RESOURCE_OUTPUT_${UPPER_FORMAT}_PATH}")
+        list(APPEND COMPILED_RESOURCES_BASENAME "${RESOURCE_NAME_WE}.${BUNDLES_${UPPER_FORMAT}_SUFFIX}")
+    endforeach(RESOURCE_SOURCE)
+    # convert semicolon separated list to a space separated list
+    # NOTE: if the pkglist.txt file starts (or ends?) with a whitespace, pkgdata add an undefined symbol (named <package>_) for it
+    string(REPLACE ";" " " COMPILED_RESOURCES_BASENAME "${COMPILED_RESOURCES_BASENAME}")
+
+    if(PARSED_ARGS_PACKAGE)
+        # create a text file (pkglist.txt) with the list of the *.res to package together
+        add_custom_command(
+            OUTPUT "${PACKAGE_LIST_OUTPUT_PATH}"
+            COMMAND ${CMAKE_COMMAND} -E echo "${COMPILED_RESOURCES_BASENAME}" > "${PACKAGE_LIST_OUTPUT_PATH}"
+            DEPENDS ${COMPILED_RESOURCES_PATH}
+        )
+        # run pkgdata from pkglist.txt
+        add_custom_command(
+            OUTPUT "${PACKAGE_OUTPUT_PATH}"
+            COMMAND ${CMAKE_COMMAND} -E chdir ${RESOURCE_GENRB_CHDIR_DIR} ${${ICU_PUBLIC_VAR_NS}_PKGDATA_EXECUTABLE} -F ${PKGDATA_${TYPE}_OPTIONS} -s ${PACKAGE_NAME_WE} -p ${PACKAGE_NAME_WE} ${PACKAGE_LIST_OUTPUT_PATH}
+            DEPENDS "${PACKAGE_LIST_OUTPUT_PATH}"
+            VERBATIM
+        )
+        if(PKGDATA_LIBRARY_${TYPE}_TYPE)
+            # assert(${PARSED_ARGS_DEPENDS} != "")
+            if(NOT PARSED_ARGS_DEPENDS)
+                message(FATAL_ERROR "${__FUNCTION__}(): static and library mode imply a list of targets to link to, DEPENDS parameter missing")
+            endif(NOT PARSED_ARGS_DEPENDS)
+            add_library(${PACKAGE_TARGET_NAME} ${PKGDATA_LIBRARY_${TYPE}_TYPE} IMPORTED)
+            if(MSVC)
+                string(REGEX REPLACE "${PKGDATA_LIBRARY_SUFFIX}\$" "${CMAKE_IMPORT_LIBRARY_SUFFIX}" PACKAGE_OUTPUT_LIB "${PACKAGE_OUTPUT_PATH}")
+                set_target_properties(${PACKAGE_TARGET_NAME} PROPERTIES IMPORTED_LOCATION ${PACKAGE_OUTPUT_PATH} IMPORTED_IMPLIB ${PACKAGE_OUTPUT_LIB})
+            else(MSVC)
+                set_target_properties(${PACKAGE_TARGET_NAME} PROPERTIES IMPORTED_LOCATION ${PACKAGE_OUTPUT_PATH})
+            endif(MSVC)
+            foreach(DEPENDENCY ${PARSED_ARGS_DEPENDS})
+                target_link_libraries(${DEPENDENCY} ${PACKAGE_TARGET_NAME})
+                if(NOT PARSED_ARGS_NO_SHARED_FLAGS)
+                    get_property(ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
+                    list(LENGTH "${ENABLED_LANGUAGES}" ENABLED_LANGUAGES_LENGTH)
+                    if(ENABLED_LANGUAGES_LENGTH GREATER 1)
+                        message(WARNING "Project has more than one language enabled, skip automatic shared flags appending")
+                    else(ENABLED_LANGUAGES_LENGTH GREATER 1)
+                        set_property(TARGET "${DEPENDENCY}" APPEND PROPERTY COMPILE_FLAGS "${${ICU_PUBLIC_VAR_NS}_${ENABLED_LANGUAGES}_SHARED_FLAGS}")
+                    endif(ENABLED_LANGUAGES_LENGTH GREATER 1)
+                endif(NOT PARSED_ARGS_NO_SHARED_FLAGS)
+            endforeach(DEPENDENCY)
+            # http://www.mail-archive.com/cmake-commits@cmake.org/msg01135.html
+            set(PACKAGE_INTERMEDIATE_TARGET_NAME "${PACKAGE_TARGET_NAME}${TARGET_SEPARATOR}DUMMY")
+            # dummy intermediate target (ICU+PKG+<name>+DUMMY) to link the package to the produced library by running pkgdata (see add_custom_command above)
+            add_custom_target(
+                ${PACKAGE_INTERMEDIATE_TARGET_NAME}
+                COMMENT ""
+                DEPENDS "${PACKAGE_OUTPUT_PATH}"
+            )
+            add_dependencies("${PACKAGE_TARGET_NAME}" "${PACKAGE_INTERMEDIATE_TARGET_NAME}")
+        else(PKGDATA_LIBRARY_${TYPE}_TYPE)
+            # dummy target (ICU+PKG+<name>) to run pkgdata (see add_custom_command above)
+            add_custom_target(
+                "${PACKAGE_TARGET_NAME}" ALL
+                COMMENT ""
+                DEPENDS "${PACKAGE_OUTPUT_PATH}"
+            )
+        endif(PKGDATA_LIBRARY_${TYPE}_TYPE)
+        # dummy target (ICU+PKG+<name>+PKGLIST) to build the file pkglist.txt
+        add_custom_target(
+            "${PACKAGE_LIST_TARGET_NAME}" ALL
+            COMMENT ""
+            DEPENDS "${PACKAGE_LIST_OUTPUT_PATH}"
+        )
+        # package => pkglist.txt
+        add_dependencies("${PACKAGE_TARGET_NAME}" "${PACKAGE_LIST_TARGET_NAME}")
+        # pkglist.txt => *.res
+        add_dependencies("${PACKAGE_LIST_TARGET_NAME}" ${TARGET_RESOURCES})
+
+        if(PARSED_ARGS_DESTINATION)
+            install(FILES "${PACKAGE_OUTPUT_PATH}" DESTINATION ${PARSED_ARGS_DESTINATION} PERMISSIONS OWNER_READ GROUP_READ WORLD_READ)
+        endif(PARSED_ARGS_DESTINATION)
+    endif(PARSED_ARGS_PACKAGE)
+
+endfunction(icu_generate_resource_bundle)
+
+########## </resource bundle support> ##########
+
+########## <debug> ##########
+
+if(${ICU_PUBLIC_VAR_NS}_DEBUG)
+
+    function(icudebug _VARNAME)
+        if(DEFINED ${ICU_PUBLIC_VAR_NS}_${_VARNAME})
+            message("${ICU_PUBLIC_VAR_NS}_${_VARNAME} = ${${ICU_PUBLIC_VAR_NS}_${_VARNAME}}")
+        else(DEFINED ${ICU_PUBLIC_VAR_NS}_${_VARNAME})
+            message("${ICU_PUBLIC_VAR_NS}_${_VARNAME} = <UNDEFINED>")
+        endif(DEFINED ${ICU_PUBLIC_VAR_NS}_${_VARNAME})
+    endfunction(icudebug)
+
+    # IN (args)
+    icudebug("FIND_COMPONENTS")
+    icudebug("FIND_REQUIRED")
+    icudebug("FIND_QUIETLY")
+    icudebug("FIND_VERSION")
+
+    # OUT
+    # Found
+    icudebug("FOUND")
+    # Flags
+    icudebug("C_FLAGS")
+    icudebug("CPP_FLAGS")
+    icudebug("CXX_FLAGS")
+    icudebug("C_SHARED_FLAGS")
+    icudebug("CPP_SHARED_FLAGS")
+    icudebug("CXX_SHARED_FLAGS")
+    # Linking
+    icudebug("INCLUDE_DIRS")
+    icudebug("LIBRARIES")
+    # Version
+    icudebug("VERSION_MAJOR")
+    icudebug("VERSION_MINOR")
+    icudebug("VERSION_PATCH")
+    icudebug("VERSION")
+    # <COMPONENT>_(FOUND|LIBRARY)
+    set(${ICU_PRIVATE_VAR_NS}_COMPONENT_VARIABLES "FOUND" "LIBRARY" "LIBRARY_RELEASE" "LIBRARY_DEBUG")
+    foreach(${ICU_PRIVATE_VAR_NS}_COMPONENT ${${ICU_PRIVATE_VAR_NS}_COMPONENTS})
+        string(TOUPPER "${${ICU_PRIVATE_VAR_NS}_COMPONENT}" ${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT)
+        foreach(${ICU_PRIVATE_VAR_NS}_COMPONENT_VARIABLE ${${ICU_PRIVATE_VAR_NS}_COMPONENT_VARIABLES})
+            icudebug("${${ICU_PRIVATE_VAR_NS}_UPPER_COMPONENT}_${${ICU_PRIVATE_VAR_NS}_COMPONENT_VARIABLE}")
+        endforeach(${ICU_PRIVATE_VAR_NS}_COMPONENT_VARIABLE)
+    endforeach(${ICU_PRIVATE_VAR_NS}_COMPONENT)
+
+endif(${ICU_PUBLIC_VAR_NS}_DEBUG)
+
+########## </debug> ##########

--- a/cmake/modules/FindMariaDBClient.cmake
+++ b/cmake/modules/FindMariaDBClient.cmake
@@ -1,0 +1,60 @@
+# MIT License
+#
+# Copyright (c) 2018 The ViaDuck Project
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+# - Try to find MariaDB client library. This matches both the "old" client library and the new C connector.
+# Once found this will define
+#  MariaDBClient_FOUND - System has MariaDB client library
+#  MariaDBClient_INCLUDE_DIRS - The MariaDB client library include directories
+#  MariaDBClient_LIBRARIES - The MariaDB client library
+
+# includes
+find_path(MariaDBClient_INCLUDE_DIR
+        NAMES mysql.h
+        PATH_SUFFIXES mariadb mysql
+        )
+
+# library
+set(BAK_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_SHARED_LIBRARY_SUFFIX})
+find_library(MariaDBClient_LIBRARY
+        NAMES mariadb mariadbclient mysqlclient
+        PATH_SUFFIXES mariadb mysql
+        )
+set(CMAKE_FIND_LIBRARY_SUFFIXES ${BAK_CMAKE_FIND_LIBRARY_SUFFIXES})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(MariaDBClient DEFAULT_MSG MariaDBClient_LIBRARY MariaDBClient_INCLUDE_DIR)
+
+if(MariaDBClient_FOUND)
+    if(NOT TARGET MariaDBClient::MariaDBClient)
+		add_library(MariaDBClient::MariaDBClient UNKNOWN IMPORTED)
+        set_target_properties(MariaDBClient::MariaDBClient PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${MariaDBClient_INCLUDE_DIR}"
+			IMPORTED_LOCATION "${MariaDBClient_LIBRARY}")
+    endif()
+endif()
+
+mark_as_advanced(MariaDBClient_INCLUDE_DIR MariaDBClient_LIBRARY)
+
+set(MariaDBClient_LIBRARIES ${MariaDBClient_LIBRARY})
+set(MariaDBClient_INCLUDE_DIRS ${MariaDBClient_INCLUDE_DIR})

--- a/cmake/modules/FindOrBuildGTest.cmake
+++ b/cmake/modules/FindOrBuildGTest.cmake
@@ -1,0 +1,45 @@
+# MIT License
+#
+# Copyright (c) 2017-2018 The ViaDuck Project
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+set(GTEST_SRC_DIR "" CACHE PATH "Path to GTest source")
+
+if (GTEST_SRC_DIR)
+    message(STATUS "Path to GTest source specified; adding to project")
+
+    # add subdirectory so that gtest is built automatically
+    if (NOT TARGET gtest)
+        add_subdirectory(${GTEST_SRC_DIR} ${CMAKE_CURRENT_BINARY_DIR}/gtest)
+    endif()
+    set(GTEST_FOUND TRUE)
+    set(GTEST_BOTH_LIBRARIES gtest gtest_main)
+else()
+    if (NOT GTEST_FOUND)
+        message(STATUS "No path to GTest source specified. Trying to find GTest.")
+
+        find_package(GTest)
+
+        if (GTEST_FOUND)
+            message(STATUS "Found GTest.")
+        endif()
+    endif()
+endif()

--- a/cmake/modules/GetGitRevisionDescription.cmake
+++ b/cmake/modules/GetGitRevisionDescription.cmake
@@ -1,0 +1,168 @@
+# - Returns a version string from Git
+#
+# These functions force a re-configure on each git commit so that you can
+# trust the values of the variables in your build system.
+#
+#  get_git_head_revision(<refspecvar> <hashvar> [<additional arguments to git describe> ...])
+#
+# Returns the refspec and sha hash of the current head revision
+#
+#  git_describe(<var> [<additional arguments to git describe> ...])
+#
+# Returns the results of git describe on the source tree, and adjusting
+# the output so that it tests false if an error occurs.
+#
+#  git_get_exact_tag(<var> [<additional arguments to git describe> ...])
+#
+# Returns the results of git describe --exact-match on the source tree,
+# and adjusting the output so that it tests false if there was no exact
+# matching tag.
+#
+#  git_local_changes(<var>)
+#
+# Returns either "CLEAN" or "DIRTY" with respect to uncommitted changes.
+# Uses the return code of "git diff-index --quiet HEAD --".
+# Does not regard untracked files.
+#
+# Requires CMake 2.6 or newer (uses the 'function' command)
+#
+# Original Author:
+# 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2009-2010.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+if(__get_git_revision_description)
+	return()
+endif()
+set(__get_git_revision_description YES)
+
+# We must run the following at "include" time, not at function call time,
+# to find the path to this module rather than the path to a calling list file
+get_filename_component(_gitdescmoddir ${CMAKE_CURRENT_LIST_FILE} PATH)
+
+function(get_git_head_revision _refspecvar _hashvar)
+	set(GIT_PARENT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+	set(GIT_DIR "${GIT_PARENT_DIR}/.git")
+	while(NOT EXISTS "${GIT_DIR}")	# .git dir not found, search parent directories
+		set(GIT_PREVIOUS_PARENT "${GIT_PARENT_DIR}")
+		get_filename_component(GIT_PARENT_DIR ${GIT_PARENT_DIR} PATH)
+		if(GIT_PARENT_DIR STREQUAL GIT_PREVIOUS_PARENT)
+			# We have reached the root directory, we are not in git
+			set(${_refspecvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
+			set(${_hashvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
+			return()
+		endif()
+		set(GIT_DIR "${GIT_PARENT_DIR}/.git")
+	endwhile()
+	# check if this is a submodule
+	if(NOT IS_DIRECTORY ${GIT_DIR})
+		file(READ ${GIT_DIR} submodule)
+		string(REGEX REPLACE "gitdir: (.*)\n$" "\\1" GIT_DIR_RELATIVE ${submodule})
+		get_filename_component(SUBMODULE_DIR ${GIT_DIR} PATH)
+		get_filename_component(GIT_DIR ${SUBMODULE_DIR}/${GIT_DIR_RELATIVE} ABSOLUTE)
+	endif()
+	set(GIT_DATA "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/git-data")
+	if(NOT EXISTS "${GIT_DATA}")
+		file(MAKE_DIRECTORY "${GIT_DATA}")
+	endif()
+
+	if(NOT EXISTS "${GIT_DIR}/HEAD")
+		return()
+	endif()
+	set(HEAD_FILE "${GIT_DATA}/HEAD")
+	configure_file("${GIT_DIR}/HEAD" "${HEAD_FILE}" COPYONLY)
+
+	configure_file("${_gitdescmoddir}/GetGitRevisionDescription.cmake.in"
+		"${GIT_DATA}/grabRef.cmake"
+		@ONLY)
+	include("${GIT_DATA}/grabRef.cmake")
+
+	set(${_refspecvar} "${HEAD_REF}" PARENT_SCOPE)
+	set(${_hashvar} "${HEAD_HASH}" PARENT_SCOPE)
+endfunction()
+
+function(git_describe _var)
+	if(NOT GIT_FOUND)
+		find_package(Git QUIET)
+	endif()
+	get_git_head_revision(refspec hash)
+	if(NOT GIT_FOUND)
+		set(${_var} "GIT-NOTFOUND" PARENT_SCOPE)
+		return()
+	endif()
+	if(NOT hash)
+		set(${_var} "HEAD-HASH-NOTFOUND" PARENT_SCOPE)
+		return()
+	endif()
+
+	# TODO sanitize
+	#if((${ARGN}" MATCHES "&&") OR
+	#	(ARGN MATCHES "||") OR
+	#	(ARGN MATCHES "\\;"))
+	#	message("Please report the following error to the project!")
+	#	message(FATAL_ERROR "Looks like someone's doing something nefarious with git_describe! Passed arguments ${ARGN}")
+	#endif()
+
+	#message(STATUS "Arguments to execute_process: ${ARGN}")
+
+	execute_process(COMMAND
+		"${GIT_EXECUTABLE}"
+		describe
+		${hash}
+		${ARGN}
+		WORKING_DIRECTORY
+		"${CMAKE_CURRENT_SOURCE_DIR}"
+		RESULT_VARIABLE
+		res
+		OUTPUT_VARIABLE
+		out
+		ERROR_QUIET
+		OUTPUT_STRIP_TRAILING_WHITESPACE)
+	if(NOT res EQUAL 0)
+		set(out "${out}-${res}-NOTFOUND")
+	endif()
+
+	set(${_var} "${out}" PARENT_SCOPE)
+endfunction()
+
+function(git_get_exact_tag _var)
+	git_describe(out --exact-match ${ARGN})
+	set(${_var} "${out}" PARENT_SCOPE)
+endfunction()
+
+function(git_local_changes _var)
+	if(NOT GIT_FOUND)
+		find_package(Git QUIET)
+	endif()
+	get_git_head_revision(refspec hash)
+	if(NOT GIT_FOUND)
+		set(${_var} "GIT-NOTFOUND" PARENT_SCOPE)
+		return()
+	endif()
+	if(NOT hash)
+		set(${_var} "HEAD-HASH-NOTFOUND" PARENT_SCOPE)
+		return()
+	endif()
+
+	execute_process(COMMAND
+		"${GIT_EXECUTABLE}"
+		diff-index --quiet HEAD --
+		WORKING_DIRECTORY
+		"${CMAKE_CURRENT_SOURCE_DIR}"
+		RESULT_VARIABLE
+		res
+		OUTPUT_VARIABLE
+		out
+		ERROR_QUIET
+		OUTPUT_STRIP_TRAILING_WHITESPACE)
+	if(res EQUAL 0)
+		set(${_var} "CLEAN" PARENT_SCOPE)
+	else()
+		set(${_var} "DIRTY" PARENT_SCOPE)
+	endif()
+endfunction()

--- a/cmake/modules/GetGitRevisionDescription.cmake.in
+++ b/cmake/modules/GetGitRevisionDescription.cmake.in
@@ -1,0 +1,41 @@
+#
+# Internal file for GetGitRevisionDescription.cmake
+#
+# Requires CMake 2.6 or newer (uses the 'function' command)
+#
+# Original Author:
+# 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2009-2010.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+set(HEAD_HASH)
+
+file(READ "@HEAD_FILE@" HEAD_CONTENTS LIMIT 1024)
+
+string(STRIP "${HEAD_CONTENTS}" HEAD_CONTENTS)
+if(HEAD_CONTENTS MATCHES "ref")
+	# named branch
+	string(REPLACE "ref: " "" HEAD_REF "${HEAD_CONTENTS}")
+	if(EXISTS "@GIT_DIR@/${HEAD_REF}")
+		configure_file("@GIT_DIR@/${HEAD_REF}" "@GIT_DATA@/head-ref" COPYONLY)
+	else()
+		configure_file("@GIT_DIR@/packed-refs" "@GIT_DATA@/packed-refs" COPYONLY)
+		file(READ "@GIT_DATA@/packed-refs" PACKED_REFS)
+		if(${PACKED_REFS} MATCHES "([0-9a-z]*) ${HEAD_REF}")
+			set(HEAD_HASH "${CMAKE_MATCH_1}")
+		endif()
+	endif()
+else()
+	# detached HEAD
+	configure_file("@GIT_DIR@/HEAD" "@GIT_DATA@/head-ref" COPYONLY)
+endif()
+
+if(NOT HEAD_HASH)
+	file(READ "@GIT_DATA@/head-ref" HEAD_HASH LIMIT 1024)
+	string(STRIP "${HEAD_HASH}" HEAD_HASH)
+endif()

--- a/cmake/modules/README.md
+++ b/cmake/modules/README.md
@@ -1,0 +1,14 @@
+# Common CMake Modules
+CMake modules used by multiple ViaDuck projects.  
+This collection contains modules written by The ViaDuck Project as well as
+(modified) modules written by other authors.
+
+## Licensing
+The modules are subject to different licenses. See each `.cmake` file for
+licensing information.  
+  
+Modules written by The ViaDuck Project are subject to the MIT license. This
+applies to the following files:
+
+* `Doxygen.cmake`
+* `FindOrBuildGTest.cmake`

--- a/cmake/modules/toolchains/mingw64-i686.cmake
+++ b/cmake/modules/toolchains/mingw64-i686.cmake
@@ -1,0 +1,20 @@
+# Toolchain file for Windows i686 (mingw)
+
+set(CMAKE_SYSTEM_NAME Windows)
+set(TOOLCHAIN_PREFIX i686-w64-mingw32)
+
+# cross compilers to use for C and C++
+set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}-gcc)
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
+set(CMAKE_RC_COMPILER ${TOOLCHAIN_PREFIX}-windres)
+
+# target environment on the build host system
+#   set 1st to dir with the cross compiler's C/C++ headers/libs
+set(CMAKE_FIND_ROOT_PATH /usr/${TOOLCHAIN_PREFIX})
+
+# modify default behavior of FIND_XXX() commands to
+# search for headers/libs in the target environment and
+# search for programs in the build host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/cmake/modules/toolchains/mingw64-x86_64.cmake
+++ b/cmake/modules/toolchains/mingw64-x86_64.cmake
@@ -1,0 +1,20 @@
+# Toolchain file for Windows x86_64 (mingw)
+
+set(CMAKE_SYSTEM_NAME Windows)
+set(TOOLCHAIN_PREFIX x86_64-w64-mingw32)
+
+# cross compilers to use for C and C++
+set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}-gcc)
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
+set(CMAKE_RC_COMPILER ${TOOLCHAIN_PREFIX}-windres)
+
+# target environment on the build host system
+#   set 1st to dir with the cross compiler's C/C++ headers/libs
+set(CMAKE_FIND_ROOT_PATH /usr/${TOOLCHAIN_PREFIX})
+
+# modify default behavior of FIND_XXX() commands to
+# search for headers/libs in the target environment and
+# search for programs in the build host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)


### PR DESCRIPTION
1. Integrate files of git submodule in this repository

Reasons for that:

- If a change of the CMake configuration effects this
  and the repository of the submodule, two pull requests
  must be created, which complicates the contribution to
  this repository.
- The integration of this repository into the infrastructure
  of existing package managers is simplified
- If this PR is accepted we can further address the files in `cmake/modules`, which were
  previously located in the submodule. As far as I see it most of the files are needed to
  build the documentation. Maybe a bunch of them can be replaced by the command
  `doxygen_add_docs` which is available if `find_package(Doxygen)` was successful.

Maybe you still want to keep the submodule. Please note that I just changed the find
module `FindMariaDBClient.cmake`.

2. CMakeLists.txt modernization

- Installation of an export set: This enables the integration of
  this package into CMake's package management system. Thus a user
  of this package can simply use `find_package(mariadbclientpp)`
  to use this package in his own CMake project
- Correct declaration of PUBLIC dependencies (Threads and MariaDBClient)
- Change of default build options. Tests and documentation are disabled in the default build, which
  makes sense if you want to integrate this package into existing package managers.