### PR TITLE
Added option to disable cerr messages

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "external/cmake-modules"]
 	path = external/cmake-modules
-	url = ../cmake-modules.git
+	url = git@github.com:viaduck/cmake-modules.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,10 @@ cmake_minimum_required(VERSION 3.8)
 project(mariadbclientpp LANGUAGES CXX)
 
 include(GNUInstallDirs)
+cmake_policy(SET CMP0077 NEW) # set() overrides option()
 option(MARIADBPP_TEST "Build mariadbpp tests" OFF)
 option(MARIADBPP_DOC "Build mariadbpp docs" OFF)
+option(MARIADBPP_CERR_OUTPUT "Enable print to error output" ON)
 
 # add additional cmake modules
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/external/cmake-modules")
@@ -16,6 +18,14 @@ list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/external/cmake-modu
 # dependencies
 find_package(MariaDBClient REQUIRED)
 find_package(Threads REQUIRED)
+
+#options
+
+if(MARIADBPP_CERR_OUTPUT)
+	add_compile_definitions(MARIADB_CERR_OUTPUT=1)
+else()
+	add_compile_definitions(MARIADB_CERR_OUTPUT=0)
+endif()
 
 # find files
 file(GLOB mariadbclientpp_PUBLIC_HEADERS include/mariadb++/*)

--- a/src/private.hpp
+++ b/src/private.hpp
@@ -48,11 +48,16 @@ inline int gmtime_safe(struct tm* _tm, const time_t* _time) {
 #define MARIADB_ERROR_THROW_TIME(_hour, _minute, _second, _millisecond) \
     throw exception::time(_hour, _minute, _second, _millisecond);
 
+#if defined(MARIADB_CERR_OUTPUT) && MARIADB_CERR_OUTPUT
 #define MARIADB_ERROR(error_id, error)                                                             \
     std::cerr << "MariaDB Error(" << error_id << "): " << error                                    \
               << "\nIn function: " << __FUNCTION__ << "\nIn file " << __FILE__ << "\nOn line "     \
               << __LINE__ << '\n';                                                                 \
     MARIADB_ERROR_THROW_CONNECTION(error_id, error)
+#else
+#define MARIADB_ERROR(error_id, error) \
+    MARIADB_ERROR_THROW_CONNECTION(error_id, error)
+#endif
 
 #define MYSQL_ERROR_NO_BRAKET(mysql)      \
     m_last_error_no = mysql_errno(mysql); \


### PR DESCRIPTION
Hi, I was just working with the error handling and I found out that i cannot disabled the logging into std::cerr when I use try catch.
So to prevent spamming the console I've added an option to cmake to disable this feature.

Hope it will help somebody.