### PR TITLE
Allow variable length columns to be fetched through unbuffered prepared statements

### DIFF
--- a/include/mariadb++/bind.hpp
+++ b/include/mariadb++/bind.hpp
@@ -47,6 +47,8 @@ public:
 
     bool is_null() const;
 
+    bool resize();
+
     void set(enum_field_types type, const char *buffer = nullptr, unsigned long length = 0, bool us = false);
 
 private:

--- a/include/mariadb++/result_set.hpp
+++ b/include/mariadb++/result_set.hpp
@@ -189,6 +189,11 @@ private:
     explicit result_set(connection *conn, const statement_data_ref &stmt);
 
     /**
+     * Resizes bind buffers for truncated columns after a failed fetch and fetches them again
+     */
+    bool fetch_truncated();
+
+    /**
      * Throws if the result set was created, but no row was ever fetched (using next())
      */
     void check_row_fetched() const;

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -46,6 +46,16 @@ bool bind::is_null() const {
     return (m_is_null != 0);
 }
 
+bool bind::resize() {
+    if (m_data && m_data->size() < m_bind->buffer_length) {
+        if (!m_data->resize(m_bind->buffer_length))
+            return false;
+        m_bind->buffer = m_data->get();
+        m_bind->buffer_length = m_data->size();
+    }
+    return true;
+}
+
 void bind::set(enum_field_types type, const char *buffer, unsigned long length, bool us) {
     m_bind->buffer_type = type;
     m_bind->is_unsigned = us ? 1 : 0;

--- a/src/result_set.cpp
+++ b/src/result_set.cpp
@@ -99,6 +99,7 @@ bool result_set::fetch_truncated() {
                 return false;
         }
     }
+    return true;
 }
 
 u32 result_set::column_count() const {

--- a/src/result_set.cpp
+++ b/src/result_set.cpp
@@ -89,6 +89,18 @@ result_set::~result_set() {
     }
 }
 
+bool result_set::fetch_truncated() {
+    for (u32 i = 0; i < m_field_count; ++i) {
+        if (m_binds[i]->m_error) {
+            if (!m_binds[i]->resize())
+                return false;
+            m_row[i] = m_binds[i]->buffer();
+            if (mysql_stmt_fetch_column(m_stmt_data->m_statement, m_binds[i]->m_bind, i, 0))
+                return false;
+        }
+    }
+}
+
 u32 result_set::column_count() const {
     return m_field_count;
 }
@@ -193,8 +205,12 @@ bool result_set::next() {
     if (!m_result_set)
         return (m_was_fetched = false);
 
-    if (m_stmt_data)
-        return (m_was_fetched = !mysql_stmt_fetch(m_stmt_data->m_statement));
+    if (m_stmt_data) {
+        int ret = mysql_stmt_fetch(m_stmt_data->m_statement);
+        if (ret == MYSQL_DATA_TRUNCATED)
+            return (m_was_fetched = fetch_truncated());
+        return (m_was_fetched = !ret);
+    }
 
     m_row = mysql_fetch_row(m_result_set);
     m_lengths = mysql_fetch_lengths(m_result_set);


### PR DESCRIPTION
The result set implementation for prepared statements currently assumes the `mysql_stmt_fetch` to either succeed or fail completely. There is, however, the case of truncated results (return code `MYSQL_DATA_TRUNCATED`) if one or more of the binding buffers were too small.

In such a case, the buffers should be resized and the respective columns should be fetched again, as [the MySQL documentation for `mysql-stmt-fetch`](https://dev.mysql.com/doc/c-api/8.0/en/mysql-stmt-fetch.html) suggests.
I've added the corresponding code - let me know what you think.

For performance reasons, one could also resize the buffers exponentially to avoid repeated resizes by small amounts, but I've kept it simple in the first step...