### PR TITLE
Run test suite with unbuffered queries

### DIFF
--- a/test/AlterTableTest.cpp
+++ b/test/AlterTableTest.cpp
@@ -13,38 +13,40 @@ void AlterTableTest::CreateTestTable() {
                    " (id INT AUTO_INCREMENT, PRIMARY KEY (`id`));");
 }
 
-TEST_F(AlterTableTest, AlterAddAndDrop_existing) {
+TEST_P(AlterTableTest, AlterAddAndDrop_existing) {
     m_con->execute("ALTER TABLE " + m_table_name + " ADD new INT;");
     m_con->execute("ALTER TABLE " + m_table_name + " DROP COLUMN new;");
 }
 
-TEST_F(AlterTableTest, AlterAddAndModify_existing) {
+TEST_P(AlterTableTest, AlterAddAndModify_existing) {
     m_con->execute("ALTER TABLE " + m_table_name + " ADD new INT;");
     m_con->execute("ALTER TABLE " + m_table_name + " MODIFY new DOUBLE NOT NULL;");
 }
 
-TEST_F(AlterTableTest, AlterAdd_non_existing_table) {
+TEST_P(AlterTableTest, AlterAdd_non_existing_table) {
     EXPECT_ANY_THROW(m_con->execute("ALTER TABLE doesntexist ADD new INT;"));
 }
 
-TEST_F(AlterTableTest, AlterDrop_non_existing_table) {
+TEST_P(AlterTableTest, AlterDrop_non_existing_table) {
     EXPECT_ANY_THROW(m_con->execute("ALTER TABLE doesntexist DROP COLUMN new;"));
 }
 
-TEST_F(AlterTableTest, AlterModify_non_existing_table) {
+TEST_P(AlterTableTest, AlterModify_non_existing_table) {
     EXPECT_ANY_THROW(m_con->execute("ALTER TABLE doesntexist MODIFY new DOUBLE;"));
 }
 
-TEST_F(AlterTableTest, AlterModify_non_existing_column) {
+TEST_P(AlterTableTest, AlterModify_non_existing_column) {
     m_con->execute("ALTER TABLE " + m_table_name + " ADD new INT;");
     EXPECT_ANY_THROW(
         m_con->execute("ALTER TABLE " + m_table_name + " MODIFY new_doesntexist DOUBLE;"));
 }
 
-TEST_F(AlterTableTest, AlterAddAndDrop_no_connect) {
+TEST_P(AlterTableTest, AlterAddAndDrop_no_connect) {
     account_ref no_acc = account::create("256.256.256.256", "", "");
     connection_ref no_conn = connection::create(no_acc);
 
     EXPECT_ANY_THROW(no_conn->execute("ALTER TABLE " + m_table_name + " ADD new INT;"));
     EXPECT_ANY_THROW(no_conn->execute("ALTER TABLE " + m_table_name + " DROP COLUMN new;"));
 }
+
+INSTANTIATE_TEST_SUITE_P(BufUnbuf, AlterTableTest, ::testing::Values(true, false));

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,7 +33,7 @@ if (GTEST_FOUND)
     add_executable(mariadbpp_tests ${mariadbclientpp_SOURCES} ${mariadbclientpp_PUBLIC_HEADERS}
                                         ${mariadbpp_tests_HEADERS} ${mariadbpp_tests_SOURCES})
 
-    target_link_libraries(mariadbpp_tests mariadbclientpp gtest_main)
+    target_link_libraries(mariadbpp_tests mariadbclientpp gtest_main gtest)
 
     if (NOT WIN32 AND NOT ANDROID)
         include(CodeCoverage)

--- a/test/GeneralTest.cpp
+++ b/test/GeneralTest.cpp
@@ -9,7 +9,7 @@
 #include "GeneralTest.h"
 #include "mariadb++/concurrency.hpp"
 
-TEST_F(GeneralTest, testCreateFail) {
+TEST_P(GeneralTest, testCreateFail) {
     // intended syntax error
     ASSERT_ANY_THROW(m_con->execute("CREATE TAVBEL testtest ();"));
     ASSERT_ANY_THROW(m_con->execute("CREATE TABLE testtest (\");"));
@@ -17,7 +17,7 @@ TEST_F(GeneralTest, testCreateFail) {
     ASSERT_ANY_THROW(m_con->execute("CREATE TABLE ()"));
 }
 
-TEST_F(GeneralTest, testMissingConnection) {
+TEST_P(GeneralTest, testMissingConnection) {
     // create connection without connecting
     account_ref no_acc = account::create("0.0.0.0", "", "");
     connection_ref no_conn = connection::create(no_acc);
@@ -30,12 +30,12 @@ TEST_F(GeneralTest, testMissingConnection) {
     EXPECT_ANY_THROW(no_conn->create_statement("SELECT * FROM asdf;"));
 }
 
-TEST_F(GeneralTest, testDuplicateTable) {
+TEST_P(GeneralTest, testDuplicateTable) {
     EXPECT_ANY_THROW(m_con->execute("CREATE TABLE " + m_table_name +
                                     " (id INT AUTO_INCREMENT, PRIMARY KEY(id));"));
 }
 
-TEST_F(GeneralTest, testConcurrentInsert) {
+TEST_P(GeneralTest, testConcurrentInsert) {
     constexpr int num_results = 100;
 
     std::vector<handle> handles;
@@ -66,3 +66,5 @@ TEST_F(GeneralTest, testConcurrentInsert) {
 
     EXPECT_EQ(num_results, results.size());
 }
+
+INSTANTIATE_TEST_SUITE_P(BufUnbuf, GeneralTest, ::testing::Values(true, false));

--- a/test/ParameterizedQueryTest.cpp
+++ b/test/ParameterizedQueryTest.cpp
@@ -8,7 +8,7 @@
 
 #include "ParameterizedQueryTest.h"
 
-TEST_F(ParameterizedQueryTest, bindNormal) {
+TEST_P(ParameterizedQueryTest, bindNormal) {
     mariadb::statement_ref selectQuery =
         m_con->create_statement("SELECT * FROM " + m_table_name + " WHERE 1=?;");
     selectQuery->set_unsigned32(0, 1);
@@ -19,7 +19,7 @@ TEST_F(ParameterizedQueryTest, bindNormal) {
     ASSERT_TRUE(queryResult->next());
 }
 
-TEST_F(ParameterizedQueryTest, emptyBind) {
+TEST_P(ParameterizedQueryTest, emptyBind) {
     mariadb::statement_ref emptyQuery =
         m_con->create_statement("SELECT * FROM " + m_table_name + " WHERE 1=?;");
 
@@ -29,12 +29,12 @@ TEST_F(ParameterizedQueryTest, emptyBind) {
     ASSERT_FALSE(queryResult->next());
 }
 
-TEST_F(ParameterizedQueryTest, emptyBindQuery) {
+TEST_P(ParameterizedQueryTest, emptyBindQuery) {
     // fixme: Invalid query object instead of exception maybe?
     EXPECT_ANY_THROW(mariadb::statement_ref emptyQuery = m_con->create_statement(""));
 }
 
-TEST_F(ParameterizedQueryTest, bindAfterQuery) {
+TEST_P(ParameterizedQueryTest, bindAfterQuery) {
     mariadb::statement_ref errorQuery =
         m_con->create_statement("SELECT * FROM " + m_table_name + " WHERE id = ?;");
     mariadb::result_set_ref queryResult = errorQuery->query();
@@ -42,7 +42,7 @@ TEST_F(ParameterizedQueryTest, bindAfterQuery) {
     EXPECT_NO_THROW(errorQuery->set_unsigned32(0, 1));
 }
 
-TEST_F(ParameterizedQueryTest, bindAnyDataType) {
+TEST_P(ParameterizedQueryTest, bindAnyDataType) {
     mariadb::statement_ref errorQuery;
     mariadb::statement_ref testQuery;
     mariadb::result_set_ref queryResult;
@@ -82,7 +82,7 @@ TEST_F(ParameterizedQueryTest, bindAnyDataType) {
     ParamTest_TEST(errorQuery->set_null(0), queryResult->get_is_null(0), "nul", true);
 }
 
-TEST_F(ParameterizedQueryTest, bindExecute) {
+TEST_P(ParameterizedQueryTest, bindExecute) {
     mariadb::statement_ref crashQuery =
         m_con->create_statement("INSERT INTO " + m_table_name + " (id, preis) VALUES (2, ?);");
     crashQuery->set_unsigned32(0, 1);
@@ -90,7 +90,7 @@ TEST_F(ParameterizedQueryTest, bindExecute) {
     crashQuery->query();
 }
 
-TEST_F(ParameterizedQueryTest, bindDataBlob) {
+TEST_P(ParameterizedQueryTest, bindDataBlob) {
     mariadb::statement_ref errorQuery =
         m_con->create_statement("SELECT * FROM " + m_table_name + " WHERE id = ?;");
 
@@ -114,19 +114,19 @@ TEST_F(ParameterizedQueryTest, bindDataBlob) {
     ASSERT_FALSE(queryResult->next());
 }
 
-TEST_F(ParameterizedQueryTest, bindDataBlobNullPtr) {
+TEST_P(ParameterizedQueryTest, bindDataBlobNullPtr) {
     mariadb::statement_ref errorQuery =
         m_con->create_statement("SELECT * FROM " + m_table_name + " WHERE id = ?;");
     errorQuery->set_data(0, nullptr);
 }
 
-TEST_F(ParameterizedQueryTest, bindWithoutParameters) {
+TEST_P(ParameterizedQueryTest, bindWithoutParameters) {
     mariadb::statement_ref errorQuery = m_con->create_statement("SELECT 1;");
 
     EXPECT_ANY_THROW(errorQuery->set_unsigned32(1, 100));
 }
 
-TEST_F(ParameterizedQueryTest, bindReuseSimple) {
+TEST_P(ParameterizedQueryTest, bindReuseSimple) {
     mariadb::statement_ref insertQuery = m_con->create_statement("INSERT INTO " + m_table_name + "(preis) VALUES(?);");
 
     // bind 1
@@ -164,7 +164,7 @@ TEST_F(ParameterizedQueryTest, bindReuseSimple) {
     EXPECT_EQ(1337u, result3->get_unsigned32(0));
 }
 
-TEST_F(ParameterizedQueryTest, bindReuseString) {
+TEST_P(ParameterizedQueryTest, bindReuseString) {
     mariadb::statement_ref insertQuery = m_con->create_statement("INSERT INTO " + m_table_name + "(str) VALUES(?);");
 
     // bind 1
@@ -202,3 +202,5 @@ TEST_F(ParameterizedQueryTest, bindReuseString) {
     ASSERT_TRUE(result3->next());
     EXPECT_EQ("", result3->get_string(0));
 }
+
+INSTANTIATE_TEST_SUITE_P(BufUnbuf, ParameterizedQueryTest, ::testing::Values(true, false));

--- a/test/ParameterizedQueryTest.cpp
+++ b/test/ParameterizedQueryTest.cpp
@@ -57,7 +57,8 @@ TEST_P(ParameterizedQueryTest, bindAnyDataType) {
                                         " WHERE id = 1;");                                        \
     queryResult = testQuery->query();                                                             \
     ASSERT_TRUE(queryResult->next());                                                             \
-    ASSERT_EQ(call2, value);
+    ASSERT_EQ(call2, value);                                                                      \
+    queryResult.reset();
 
     decimal d = decimal("0.02");
     mariadb::date_time t(mariadb::date_time::now()), z(0, 0, 0);

--- a/test/RollbackTest.cpp
+++ b/test/RollbackTest.cpp
@@ -8,7 +8,7 @@
 
 #include "RollbackTest.h"
 
-TEST_F(RollbackTest, testTransactCommit) {
+TEST_P(RollbackTest, testTransactCommit) {
     transaction_ref trx = m_con->create_transaction();
 
     u64 id = m_con->insert("INSERT INTO " + m_table_name + "(str) VALUES('test');");
@@ -21,7 +21,7 @@ TEST_F(RollbackTest, testTransactCommit) {
     EXPECT_EQ(1, rs->get_unsigned64(0));
 }
 
-TEST_F(RollbackTest, testTransactionRollback) {
+TEST_P(RollbackTest, testTransactionRollback) {
     // force transaction out of scope to destruct it and trigger automatic rollback
     {
         transaction_ref trx = m_con->create_transaction();
@@ -34,7 +34,7 @@ TEST_F(RollbackTest, testTransactionRollback) {
     EXPECT_EQ(0, rs->get_unsigned64(0));
 }
 
-TEST_F(RollbackTest, testSavePointCommit) {
+TEST_P(RollbackTest, testSavePointCommit) {
     transaction_ref trx = m_con->create_transaction();
     {
         save_point_ref sp = trx->create_save_point();
@@ -50,7 +50,7 @@ TEST_F(RollbackTest, testSavePointCommit) {
     EXPECT_EQ(1, rs->get_unsigned64(0));
 }
 
-TEST_F(RollbackTest, testSavePointNoCommit) {
+TEST_P(RollbackTest, testSavePointNoCommit) {
     transaction_ref trx = m_con->create_transaction();
     {
         save_point_ref sp = trx->create_save_point();
@@ -65,7 +65,7 @@ TEST_F(RollbackTest, testSavePointNoCommit) {
     EXPECT_EQ(0, rs->get_unsigned64(0));
 }
 
-TEST_F(RollbackTest, testMultiInsertIntegration) {
+TEST_P(RollbackTest, testMultiInsertIntegration) {
     std::string queries[] = {
         "INSERT INTO " + m_table_name + " (data) VALUES(?);",
         "INSERT INTO " + m_table_name + " (data, str) VALUES(?, ?);",
@@ -122,3 +122,5 @@ TEST_F(RollbackTest, testMultiInsertIntegration) {
     EXPECT_EQ("2000-01-02 03:04:05", rs->get_date_time("dt").str());
     EXPECT_EQ("11:22:33", rs->get_time("t").str_time());
 }
+
+INSTANTIATE_TEST_SUITE_P(BufUnbuf, RollbackTest, ::testing::Values(true, false));

--- a/test/SelectTest.cpp
+++ b/test/SelectTest.cpp
@@ -9,7 +9,7 @@
 #include "SelectTest.h"
 #include <cmath>
 
-TEST_F(SelectTest, SelectEmptyTable) {
+TEST_P(SelectTest, SelectEmptyTable) {
     m_con->execute("CREATE TABLE " + m_table_name +
                    " (id INT AUTO_INCREMENT, PRIMARY KEY (`id`));");
     result_set_ref res = m_con->query("SELECT * FROM " + m_table_name);
@@ -18,7 +18,7 @@ TEST_F(SelectTest, SelectEmptyTable) {
     ASSERT_FALSE(res->next());
 }
 
-TEST_F(SelectTest, IntegerLimits) {
+TEST_P(SelectTest, IntegerLimits) {
     m_con->execute("CREATE TABLE `" + m_table_name +
                    "` (\n"
                    "\t`seq` INT(11) NULL DEFAULT NULL,\n"
@@ -77,7 +77,7 @@ TEST_F(SelectTest, IntegerLimits) {
     EXPECT_EQ(18446744073709551615ULL, res->get_unsigned64(10));
 }
 
-TEST_F(SelectTest, RealLimits) {
+TEST_P(SelectTest, RealLimits) {
     m_con->execute("CREATE TABLE `" + m_table_name +
                    "` (\n"
                    "\t`seq` INT(11) NULL DEFAULT NULL,\n"
@@ -122,3 +122,5 @@ TEST_F(SelectTest, RealLimits) {
     EXPECT_FLOAT_EQ(0, res->get_float(3));
     EXPECT_FLOAT_EQ(0, res->get_double(4));
 }
+
+INSTANTIATE_TEST_SUITE_P(BufUnbuf, SelectTest, ::testing::Values(true, false));

--- a/test/SkeletonTest.h
+++ b/test/SkeletonTest.h
@@ -11,12 +11,13 @@
 
 #include <mariadb++/connection.hpp>
 #include <gtest/gtest.h>
+#include <algorithm>
 
 #include "test_config.h"
 
 using namespace mariadb;
 
-class SkeletonTest : public ::testing::Test {
+class SkeletonTest : public ::testing::TestWithParam<bool> {
    public:
     virtual void SetUp() override {
         // get test names and concatenate them
@@ -24,6 +25,7 @@ class SkeletonTest : public ::testing::Test {
             ::testing::UnitTest::GetInstance()->current_test_info();
         m_table_name =
             std::string(test_info->test_case_name()) + "_" + std::string(test_info->name());
+        std::replace(m_table_name.begin(), m_table_name.end(), '/', '_');
 
         // create user account
         using TestConfig = mariadb::testing::TestConfig;
@@ -32,6 +34,7 @@ class SkeletonTest : public ::testing::Test {
         ASSERT_TRUE(!!m_account_setup);
         m_account_setup->set_auto_commit(true);
         m_account_setup->set_connect_option(MYSQL_OPT_CONNECT_TIMEOUT, 10);
+        m_account_setup->set_store_result(GetParam());
         ASSERT_EQ(1u, m_account_setup->connect_options().size());
 
         // create database connection

--- a/test/StructureTest.cpp
+++ b/test/StructureTest.cpp
@@ -8,7 +8,7 @@
 
 #include "StructureTest.h"
 
-TEST_F(StructureTest, testDateTime) {
+TEST_P(StructureTest, testDateTime) {
     date_time dt("2000-01-02 03:04:05.666");
     date_time dt2(2000, 1, 2, 3, 4, 5, 666);
 
@@ -23,7 +23,7 @@ TEST_F(StructureTest, testDateTime) {
     EXPECT_EQ("2000-01-12 03:04:05.666", dt2.str(true));
 }
 
-TEST_F(StructureTest, testTime) {
+TEST_P(StructureTest, testTime) {
     mariadb::time t("03:04:05.666");
     mariadb::time t2(3, 4, 5, 666);
 
@@ -37,7 +37,7 @@ TEST_F(StructureTest, testTime) {
     EXPECT_EQ("08:04:05.666", t2.str_time(true));
 }
 
-TEST_F(StructureTest, testTimeSpan) {
+TEST_P(StructureTest, testTimeSpan) {
     date_time dt(2000, 1, 2, 3, 4, 5, 666);
     date_time dt2(2000, 1, 5, 5, 5, 5, 999);
 
@@ -48,9 +48,11 @@ TEST_F(StructureTest, testTimeSpan) {
     EXPECT_EQ(333, ts.milliseconds());
 }
 
-TEST_F(StructureTest, testDecimal) {
+TEST_P(StructureTest, testDecimal) {
     decimal d("24.1234");
 
     EXPECT_EQ(24.1234, d.double64());
     EXPECT_EQ("24.1234", d.str());
 }
+
+INSTANTIATE_TEST_SUITE_P(BufUnbuf, StructureTest, ::testing::Values(true, false));

--- a/test/TimeTest.cpp
+++ b/test/TimeTest.cpp
@@ -6,10 +6,13 @@
 //    (See accompanying file LICENSE or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
+#include <chrono>
+#include <thread>
+
 #include "TimeTest.h"
 
-#define EXPECT_INVALID(t, x...) do {    \
-    t d(x);                             \
+#define EXPECT_INVALID(t, ...) do {    \
+    t d(__VA_ARGS__);                             \
     EXPECT_FALSE(d.is_valid());         \
 } while(false)
 
@@ -157,7 +160,7 @@ TEST_P(TimeTest, testNow) {
     mariadb::time un3 = time::now_utc();
 
     // make sure n4 and un4 are actually different
-    sleep(1);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
     mariadb::time n4 = time::now();
     mariadb::time un4 = time::now_utc();
 

--- a/test/TimeTest.cpp
+++ b/test/TimeTest.cpp
@@ -13,7 +13,7 @@
     EXPECT_FALSE(d.is_valid());         \
 } while(false)
 
-TEST_F(TimeTest, testConstructors) {
+TEST_P(TimeTest, testConstructors) {
     // valid times
     mariadb::time a;
     mariadb::time b(13, 37, 42, 000);
@@ -72,7 +72,7 @@ TEST_F(TimeTest, testConstructors) {
     EXPECT_EQ("08:59:59", l.str_time());
 }
 
-TEST_F(TimeTest, testArithm) {
+TEST_P(TimeTest, testArithm) {
     // test ms
     mariadb::time a(13, 37);
     mariadb::time b(13, 36, 59, 999);
@@ -120,7 +120,7 @@ TEST_F(TimeTest, testArithm) {
     ASSERT_EQ(d, e.add_milliseconds(-1));
 }
 
-TEST_F(TimeTest, testDiff) {
+TEST_P(TimeTest, testDiff) {
     mariadb::time a(13, 37, 42, 007);
     mariadb::time b(12, 37, 42, 007);
     mariadb::time c(23, 37, 42, 007);
@@ -147,7 +147,7 @@ TEST_F(TimeTest, testDiff) {
     ASSERT_NE(s31.negative(), s13.negative());
 }
 
-TEST_F(TimeTest, testNow) {
+TEST_P(TimeTest, testNow) {
     mariadb::time n1 = time::now();
     mariadb::time n2 = time::now();
     mariadb::time n3 = time::now();
@@ -173,7 +173,7 @@ TEST_F(TimeTest, testNow) {
     ASSERT_NE(un1, un4);
 }
 
-TEST_F(TimeTest, testSpan) {
+TEST_P(TimeTest, testSpan) {
     time_span a;
     time_span b(1, 3, 37, 42, 007);
     time_span c(0, 3, 37, 42, 007, true);
@@ -211,7 +211,7 @@ void readdTest(date_time smaller, date_time bigger) {
     ASSERT_EQ(bigger, smaller.add(bigger.time_between(smaller)));
 }
 
-TEST_F(TimeTest, testDateTime) {
+TEST_P(TimeTest, testDateTime) {
     date_time a;
     date_time b(2012, 12, 21, 13, 37, 42, 007);
     date_time before(2012, 12, 19, 13, 37, 42, 007);
@@ -292,3 +292,5 @@ TEST_F(TimeTest, testDateTime) {
     EXPECT_EQ("2008-02-29 13:37:42", ba.str(false));
     EXPECT_EQ("2008-02-29", ba.str_date());
 }
+
+INSTANTIATE_TEST_SUITE_P(BufUnbuf, TimeTest, ::testing::Values(true, false));

--- a/test/TruncationTest.cpp
+++ b/test/TruncationTest.cpp
@@ -20,6 +20,7 @@ TEST_P(TruncationTest, testUInt) {
     ASSERT_TRUE(!!res);
     ASSERT_TRUE(res->next());
     ASSERT_EQ(max, res->get_unsigned32(0));
+    res.reset();
 
     // query as statement
     statement_ref stmt = m_con->create_statement("SELECT * FROM " + m_table_name + ";");

--- a/test/TruncationTest.cpp
+++ b/test/TruncationTest.cpp
@@ -8,7 +8,7 @@
 
 #include "TruncationTest.h"
 
-TEST_F(TruncationTest, testUInt) {
+TEST_P(TruncationTest, testUInt) {
     uint32_t max = std::numeric_limits<uint32_t>::max();
 
     // insert max uint
@@ -29,3 +29,5 @@ TEST_F(TruncationTest, testUInt) {
     ASSERT_TRUE(stmt_res->next());
     ASSERT_EQ(max, stmt_res->get_unsigned32(0));
 }
+
+INSTANTIATE_TEST_SUITE_P(BufUnbuf, TruncationTest, ::testing::Values(true, false));


### PR DESCRIPTION
I've made the whole high-level test suite parameterized, such that it executes both with buffered queries (as before) and with unbuffered ones (new).
Also, I've made two small fixes to be able to execute the test suite: missing linkage of gtest in CMakeLists and the use of Linux-specific functions in TimeTest.

There are two failing tests with unbuffered queries:
- `ParameterizedQueryTest.bindAnyDataType`
- `ParameterizedQueryTest.bindReuseString`

These are caused by missing handling of truncated variable-length columns. A fix for this is in #46 .